### PR TITLE
Migrate to Bevy 0.18 and Rust Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "sldshow2"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 authors = ["ugai"]
 description = "Simple slideshow image viewer with custom WGSL transitions"
 license = "MIT"
@@ -10,14 +11,17 @@ homepage = "https://github.com/ugai/sldshow2"
 
 [dependencies]
 # Bevy game engine
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_winit",        # Window management
     "bevy_render",       # Rendering
     "bevy_core_pipeline", # Core rendering pipeline
     "bevy_asset",        # Asset management
     "bevy_sprite",       # 2D sprite rendering
+    "bevy_sprite_render", # 2D sprite rendering (Material2d etc.)
     "bevy_ui",           # UI components
+    "bevy_ui_render",    # UI rendering (required for UI to be visible!)
     "bevy_text",         # Text rendering
+    "bevy_log",          # Logging macros
     "png",               # PNG image format support
     "jpeg",              # JPEG image format support
     "webp",              # WebP image format support

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,16 +3,16 @@
 //! Centralized location for magic numbers and fixed asset handles.
 
 use bevy::prelude::*;
-use bevy::render::render_resource::Shader;
+use bevy::asset::uuid_handle;
 
 /// Handle for the embedded M PLUS 2 font
 ///
 /// This font is embedded in the binary using include_bytes! and
 /// assigned a fixed weak handle for standalone distribution.
-pub const EMBEDDED_FONT_HANDLE: Handle<Font> = Handle::weak_from_u128(0xabcd_1234_5678_90ef);
+pub const EMBEDDED_FONT_HANDLE: Handle<Font> = uuid_handle!("abcd1234-5678-490e-f000-000000000001");
 
 /// Handle for the embedded transition shader
 ///
 /// The WGSL shader code is embedded in the binary and assigned
 /// a fixed weak handle to ensure consistent asset loading.
-pub const TRANSITION_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(0x1234_5678_9abc_def0);
+pub const TRANSITION_SHADER_HANDLE: Handle<Shader> = uuid_handle!("12345678-9abc-4def-0000-000000000002");

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -1,7 +1,7 @@
 use crate::error::{Result, SldshowError};
 use crate::metadata::ImageMetadata;
 use bevy::prelude::*;
-use bevy::render::render_asset::RenderAssetUsages;
+use bevy::asset::RenderAssetUsages;
 use bevy::tasks::{AsyncComputeTaskPool, Task};
 use camino::{Utf8Path, Utf8PathBuf};
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,7 @@ mod watcher;
 
 use bevy::prelude::*;
 use bevy::input::mouse::{MouseButton, MouseWheel};
-use bevy::render::mesh::Mesh2d;
-use bevy::sprite::MeshMaterial2d;
+use bevy::sprite_render::MeshMaterial2d;
 use bevy::tasks::{AsyncComputeTaskPool, Task};
 use bevy::window::{WindowMode, PresentMode, MonitorSelection};
 use bevy::winit::WinitSettings;
@@ -75,7 +74,7 @@ fn main() {
                 .set(WindowPlugin {
                     primary_window: Some(Window {
                         title: "sldshow2".to_string(),
-                        resolution: (config.window.width as f32, config.window.height as f32).into(),
+                        resolution: (config.window.width as u32, config.window.height as u32).into(),
                         present_mode: PresentMode::AutoVsync,
                         decorations: config.window.decorations,
                         resizable: config.window.resizable,
@@ -137,13 +136,13 @@ fn setup(
     fonts.insert(
         &EMBEDDED_FONT_HANDLE,
         Font::try_from_bytes(font_data.to_vec()).expect("Failed to load embedded font"),
-    );
+    ).expect("Failed to insert embedded font");
 
     // Spawn camera with default 2D setup
     commands.spawn((
         Camera2d,
         Camera {
-            clear_color: bevy::render::camera::ClearColorConfig::Default,
+            clear_color: ClearColorConfig::Default,
             ..default()
         },
     ));
@@ -319,7 +318,7 @@ struct ImagePathText;
 fn detect_image_change(
     loader: Res<ImageLoader>,
     mut tracker: ResMut<ImageChangeTracker>,
-    mut transition_events: EventWriter<TransitionEvent>,
+    mut transition_events: MessageWriter<TransitionEvent>,
     config: Res<Config>,
     images: Res<Assets<Image>>,
     mut transition_state: ResMut<TransitionState>,
@@ -395,7 +394,7 @@ fn detect_image_change(
     // Handle first image (instant display)
     let Some(prev_index) = tracker.last_index else {
         info!("First image loaded - showing instantly");
-        transition_events.send(TransitionEvent {
+        transition_events.write(TransitionEvent {
             from_image: current_handle.clone(),
             to_image: current_handle.clone(),
             duration: 0.0,
@@ -412,7 +411,7 @@ fn detect_image_change(
 
     info!("Normal transition: image {} -> image {}",
           prev_index + 1, current_index + 1);
-    transition_events.send(TransitionEvent {
+    transition_events.write(TransitionEvent {
         from_image: prev_handle.clone(),
         to_image: current_handle.clone(),
         duration: config.transition.time,
@@ -424,7 +423,7 @@ fn detect_image_change(
 
 /// Get window size from query or fallback to config
 fn get_window_size(windows: &Query<&Window>, config: &Config) -> Vec2 {
-    if let Ok(window) = windows.get_single() {
+    if let Ok(window) = windows.single() {
         Vec2::new(window.width(), window.height())
     } else {
         Vec2::new(config.window.width as f32, config.window.height as f32)
@@ -531,7 +530,7 @@ fn spawn_transition_entity(
 #[allow(clippy::too_many_arguments)]
 fn trigger_transition(
     mut commands: Commands,
-    mut transition_events: EventReader<TransitionEvent>,
+    mut transition_events: MessageReader<TransitionEvent>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<TransitionMaterial>>,
     config: Res<Config>,
@@ -559,7 +558,7 @@ fn trigger_transition(
             .unwrap_or_else(|| event.from_image.clone());
 
         // Try to reuse existing entity to avoid spawn/despawn overhead
-        if let Ok((entity, material_handle)) = existing_entity.get_single() {
+        if let Ok((entity, material_handle)) = existing_entity.single() {
             if let Some(material) = materials.get_mut(&material_handle.0) {
                 update_transition_material(
                     material,
@@ -598,8 +597,8 @@ fn trigger_transition(
 fn keyboard_input_system(
     keys: Res<ButtonInput<KeyCode>>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
-    mut mouse_wheel: EventReader<MouseWheel>,
-    mut exit: EventWriter<AppExit>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
+    mut exit: MessageWriter<AppExit>,
     mut loader: ResMut<ImageLoader>,
     mut timer: ResMut<SlideshowTimer>,
     mut repeat_timer: ResMut<KeyRepeatTimer>,
@@ -610,7 +609,7 @@ fn keyboard_input_system(
     // ESC or Q to quit
     if keys.just_pressed(KeyCode::Escape) || keys.just_pressed(KeyCode::KeyQ) {
         info!("Exiting application");
-        exit.send(AppExit::Success);
+        exit.write(AppExit::Success);
     }
 
     // Check if any navigation keys are being held
@@ -635,7 +634,7 @@ fn keyboard_input_system(
         }
     } else {
         // No key held - reset timers
-        if repeat_timer.in_repeat_mode || !repeat_timer.delay_timer.finished() {
+        if repeat_timer.in_repeat_mode || !repeat_timer.delay_timer.is_finished() {
             repeat_timer.delay_timer.reset();
             repeat_timer.repeat_timer.reset();
             repeat_timer.in_repeat_mode = false;
@@ -694,7 +693,7 @@ fn keyboard_input_system(
 
     // F: toggle fullscreen
     if keys.just_pressed(KeyCode::KeyF) {
-        if let Ok(mut window) = windows.get_single_mut() {
+        if let Ok(mut window) = windows.single_mut() {
             match window.mode {
                 WindowMode::Windowed => {
                     window.mode = WindowMode::BorderlessFullscreen(MonitorSelection::Index(config.window.monitor_index));
@@ -742,7 +741,7 @@ fn keyboard_input_system(
 
 /// Handle automatic slideshow advancement based on timer events
 fn handle_slideshow_advance(
-    mut events: EventReader<SlideshowAdvanceEvent>,
+    mut events: MessageReader<SlideshowAdvanceEvent>,
     mut loader: ResMut<ImageLoader>,
     config: Res<Config>,
 ) {
@@ -810,11 +809,11 @@ fn update_transition_on_resize(
     images: Res<Assets<Image>>,
 ) {
     // Check if window size changed
-    if let Ok(window) = windows.get_single() {
+    if let Ok(window) = windows.single() {
         let new_size = Vec2::new(window.width(), window.height());
 
         // Update transition entity mesh and material
-        if let Ok((mut mesh_handle, material_handle)) = transition_query.get_single_mut() {
+        if let Ok((mut mesh_handle, material_handle)) = transition_query.single_mut() {
             // Update mesh to new window size
             let new_mesh = meshes.add(Rectangle::new(new_size.x, new_size.y));
             *mesh_handle = Mesh2d(new_mesh);

--- a/src/slideshow.rs
+++ b/src/slideshow.rs
@@ -6,7 +6,7 @@ pub struct SlideshowPlugin;
 impl Plugin for SlideshowPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SlideshowTimer>()
-            .add_event::<SlideshowAdvanceEvent>()
+            .add_message::<SlideshowAdvanceEvent>()
             .add_systems(Update, update_slideshow_timer);
     }
 }
@@ -82,21 +82,21 @@ impl SlideshowTimer {
 }
 
 /// Event emitted when slideshow should advance
-#[derive(Event)]
+#[derive(Message)]
 pub struct SlideshowAdvanceEvent;
 
 /// Update slideshow timer and emit advance events
 fn update_slideshow_timer(
     mut timer: ResMut<SlideshowTimer>,
     time: Res<Time>,
-    mut events: EventWriter<SlideshowAdvanceEvent>,
+    mut events: MessageWriter<SlideshowAdvanceEvent>,
 ) {
     if timer.paused {
         return;
     }
 
     if timer.timer.tick(time.delta()).just_finished() {
-        events.send(SlideshowAdvanceEvent);
+        events.write(SlideshowAdvanceEvent);
     }
 }
 

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -7,8 +7,9 @@
 #![allow(dead_code)]
 
 use bevy::prelude::*;
-use bevy::render::render_resource::{AsBindGroup, Shader, ShaderRef, ShaderType};
-use bevy::sprite::{Material2d, Material2dPlugin};
+use bevy::render::render_resource::{AsBindGroup, ShaderType};
+use bevy::shader::ShaderRef;
+use bevy::sprite_render::{Material2d, Material2dPlugin};
 
 use crate::consts::TRANSITION_SHADER_HANDLE;
 
@@ -25,10 +26,10 @@ impl Plugin for TransitionPlugin {
                 include_str!("../assets/shaders/transition.wgsl"),
                 file!(),
             ),
-        );
+        ).expect("Failed to insert transition shader");
 
         app.add_plugins(Material2dPlugin::<TransitionMaterial>::default())
-            .add_event::<TransitionEvent>()
+            .add_message::<TransitionEvent>()
             .init_resource::<TransitionState>();
             // Note: update_transitions is now scheduled in main.rs for explicit ordering
     }
@@ -96,7 +97,7 @@ pub struct ActiveTransition {
 }
 
 /// Event to trigger a transition
-#[derive(Event)]
+#[derive(Message)]
 pub struct TransitionEvent {
     pub from_image: Handle<Image>,
     pub to_image: Handle<Image>,
@@ -106,7 +107,7 @@ pub struct TransitionEvent {
 
 /// Handle transition events
 pub fn handle_transition_events(
-    mut events: EventReader<TransitionEvent>,
+    mut events: MessageReader<TransitionEvent>,
     mut state: ResMut<TransitionState>,
     time: Res<Time>,
     mut metrics: ResMut<crate::diagnostics::TransitionMetrics>,


### PR DESCRIPTION
## Summary
- Upgrade Bevy from 0.15 to 0.18 (3 major versions)
- Upgrade Rust edition from 2021 to 2024

## Breaking Changes

### Bevy API Migrations
- `EventWriter`/`EventReader` → `MessageWriter`/`MessageReader`
- `.send()` → `.write()`
- `add_event::<T>()` → `add_message::<T>()`
- `#[derive(Event)]` → `#[derive(Message)]`
- `Timer::finished()` → `Timer::is_finished()`
- `Query::get_single()` → `Query::single()`
- `Handle::weak_from_u128()` → `uuid_handle!()`
- `Assets::insert()` now returns `Result`

### Feature Changes
- Add `bevy_ui_render` (required for UI rendering in Bevy 0.17+)
- Add `bevy_sprite_render` (Material2d moved here)
- Add `bevy_log` (logging macros)

### Import Path Updates
- `bevy::sprite` → `bevy::sprite_render` for Material2d, MeshMaterial2d
- `bevy::shader::ShaderRef` for shader references
- `bevy::asset::uuid_handle` for weak handles

## Test Plan
- [x] `cargo build` succeeds
- [x] `cargo clippy` passes
- [x] Application runs correctly with image slideshow
- [x] Transitions work smoothly
- [x] UI text (file path) displays correctly
- [x] Keyboard controls (arrows, ESC, F, P) work
- [x] Mouse controls work

🤖 Generated with [Claude Code](https://claude.ai/code)