### PR TITLE
chore: upgrade outdated dependencies (wgpu 25, glyphon 0.9, rand 0.9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ homepage = "https://github.com/ugai/sldshow2"
 
 [dependencies]
 # Graphics & Windowing
-winit = { version = "0.29", features = ["rwh_05"] }
-wgpu = "0.19"
+winit = "0.29"
+wgpu = "25"
 pollster = "0.3"
 bytemuck = { version = "1.16", features = ["derive"] }
 env_logger = "0.11"
 log = "0.4"
-glyphon = "0.5" # Text rendering
+glyphon = "0.9" # Text rendering
 
 
 # Configuration
@@ -29,7 +29,7 @@ image = "0.25"
 
 # Utilities
 anyhow = "1.0"
-rand = "0.8"
+rand = "0.9"
 alphanumeric-sort = "1.5"
 dirs = "5.0"
 

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -60,7 +60,7 @@ impl TextureManager {
 
     pub fn shuffle_paths(&mut self) {
         use rand::seq::SliceRandom;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         self.paths.shuffle(&mut rng);
     }
 
@@ -144,14 +144,14 @@ impl TextureManager {
                     });
 
                     queue.write_texture(
-                        wgpu::ImageCopyTexture {
+                        wgpu::TexelCopyTextureInfo {
                             texture: &texture,
                             mip_level: 0,
                             origin: wgpu::Origin3d::ZERO,
                             aspect: wgpu::TextureAspect::All,
                         },
                         &img,
-                        wgpu::ImageDataLayout {
+                        wgpu::TexelCopyBufferLayout {
                             offset: 0,
                             bytes_per_row: Some(4 * width),
                             rows_per_image: Some(height),

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ impl ApplicationState {
         let size = window.inner_size();
 
         // Initialize WGPU
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             ..Default::default()
         });
@@ -116,14 +116,12 @@ impl ApplicationState {
         info!("Using adapter: {:?}", adapter.get_info());
 
         let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: None,
-                    required_features: wgpu::Features::empty(),
-                    required_limits: wgpu::Limits::default(),
-                },
-                None,
-            )
+            .request_device(&wgpu::DeviceDescriptor {
+                label: None,
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+                ..Default::default()
+            })
             .await
             .context("Failed to create device")?;
 
@@ -275,7 +273,8 @@ impl ApplicationState {
             self.surface_config.width = new_size.width;
             self.surface_config.height = new_size.height;
             self.surface.configure(&self.device, &self.surface_config);
-            self.text_renderer.resize(new_size.width, new_size.height);
+            self.text_renderer
+                .resize(&self.queue, new_size.width, new_size.height);
         }
     }
 
@@ -936,8 +935,7 @@ impl ApplicationState {
                         },
                     })],
                     depth_stencil_attachment: None,
-                    occlusion_query_set: None,
-                    timestamp_writes: None,
+                    ..Default::default()
                 });
 
                 if let Some(ref bind_group) = self.bind_group {

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -42,15 +42,15 @@ impl ScreenshotCapture {
         });
 
         copy_encoder.copy_texture_to_buffer(
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            wgpu::ImageCopyBuffer {
+            wgpu::TexelCopyBufferInfo {
                 buffer: &staging_buffer,
-                layout: wgpu::ImageDataLayout {
+                layout: wgpu::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(padded_bytes_per_row),
                     rows_per_image: Some(height),
@@ -70,7 +70,7 @@ impl ScreenshotCapture {
         buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
             let _ = sender.send(result);
         });
-        device.poll(wgpu::Maintain::Wait);
+        let _ = device.poll(wgpu::PollType::Wait);
 
         if let Ok(Ok(())) = receiver.recv() {
             let data = buffer_slice.get_mapped_range();

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use glyphon::cosmic_text::Align;
 use glyphon::{
-    Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache, TextArea,
-    TextAtlas, TextBounds, TextRenderer as GlyphonTextRenderer,
+    Attrs, Buffer, Cache, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache,
+    TextArea, TextAtlas, TextBounds, TextRenderer as GlyphonTextRenderer, Viewport,
 };
 use wgpu::{Device, MultisampleState, Queue, RenderPass, SurfaceConfiguration};
 
@@ -18,7 +18,9 @@ const INFO_OFFSET_TOP: f32 = 2.5;
 pub struct TextRenderer {
     font_system: FontSystem,
     swash_cache: SwashCache,
-    viewport: ValidationViewport,
+    #[allow(dead_code)] // Kept alive to prevent GPU cache deallocation
+    cache: Cache,
+    viewport: Viewport,
     atlas: TextAtlas,
     text_renderer: GlyphonTextRenderer,
     buffer: Buffer,
@@ -34,11 +36,6 @@ enum BufferTarget {
     Main,
     Osd,
     Info,
-}
-
-struct ValidationViewport {
-    width: u32,
-    height: u32,
 }
 
 impl TextRenderer {
@@ -100,11 +97,16 @@ impl TextRenderer {
         }
 
         let swash_cache = SwashCache::new();
-        let viewport = ValidationViewport {
-            width: config.width,
-            height: config.height,
-        };
-        let mut atlas = TextAtlas::new(device, queue, config.format);
+        let cache = Cache::new(device);
+        let mut viewport = Viewport::new(device, &cache);
+        viewport.update(
+            queue,
+            Resolution {
+                width: config.width,
+                height: config.height,
+            },
+        );
+        let mut atlas = TextAtlas::new(device, queue, &cache, config.format);
         let text_renderer =
             GlyphonTextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
         let mut buffer = Buffer::new(
@@ -120,13 +122,21 @@ impl TextRenderer {
             Metrics::new(20.0, 20.0 * LINE_HEIGHT_RATIO),
         );
 
-        buffer.set_size(&mut font_system, config.width as f32, config.height as f32);
+        buffer.set_size(
+            &mut font_system,
+            Some(config.width as f32),
+            Some(config.height as f32),
+        );
         osd_buffer.set_size(
             &mut font_system,
-            config.width as f32 - 20.0,
-            config.height as f32,
+            Some(config.width as f32 - 20.0),
+            Some(config.height as f32),
         );
-        info_buffer.set_size(&mut font_system, config.width as f32, config.height as f32);
+        info_buffer.set_size(
+            &mut font_system,
+            Some(config.width as f32),
+            Some(config.height as f32),
+        );
 
         // Note: glyphon::Attributes::family() takes a Family enum.
         // If we provide Family::Name("FoundName"), it tries to use it.
@@ -138,17 +148,14 @@ impl TextRenderer {
             Family::SansSerif
         };
 
-        buffer.set_text(
-            &mut font_system,
-            "",
-            Attrs::new().family(family),
-            Shaping::Advanced,
-        );
-        buffer.shape_until_scroll(&mut font_system);
+        let attrs = Attrs::new().family(family);
+        buffer.set_text(&mut font_system, "", &attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut font_system, true);
 
         Ok(Self {
             font_system,
             swash_cache,
+            cache,
             viewport,
             atlas,
             text_renderer,
@@ -199,35 +206,45 @@ impl TextRenderer {
         self.osd_buffer.set_metrics(&mut self.font_system, metrics);
         self.info_buffer.set_metrics(&mut self.font_system, metrics);
 
+        let res = self.viewport.resolution();
         self.osd_buffer.set_size(
             &mut self.font_system,
-            self.viewport.width as f32 - self.current_font_size,
-            self.viewport.height as f32,
+            Some(res.width as f32 - self.current_font_size),
+            Some(res.height as f32),
         );
-        self.osd_buffer.shape_until_scroll(&mut self.font_system);
+        self.osd_buffer
+            .shape_until_scroll(&mut self.font_system, true);
         self.info_buffer.set_size(
             &mut self.font_system,
-            self.viewport.width as f32,
-            self.viewport.height as f32,
+            Some(res.width as f32),
+            Some(res.height as f32),
         );
-        self.info_buffer.shape_until_scroll(&mut self.font_system);
+        self.info_buffer
+            .shape_until_scroll(&mut self.font_system, true);
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) {
-        self.viewport.width = width;
-        self.viewport.height = height;
-        self.buffer
-            .set_size(&mut self.font_system, width as f32, height as f32);
-        self.buffer.shape_until_scroll(&mut self.font_system);
+    pub fn resize(&mut self, queue: &Queue, width: u32, height: u32) {
+        self.viewport.update(queue, Resolution { width, height });
+        self.buffer.set_size(
+            &mut self.font_system,
+            Some(width as f32),
+            Some(height as f32),
+        );
+        self.buffer.shape_until_scroll(&mut self.font_system, true);
         self.osd_buffer.set_size(
             &mut self.font_system,
-            width as f32 - self.current_font_size,
-            height as f32,
+            Some(width as f32 - self.current_font_size),
+            Some(height as f32),
         );
-        self.osd_buffer.shape_until_scroll(&mut self.font_system);
+        self.osd_buffer
+            .shape_until_scroll(&mut self.font_system, true);
+        self.info_buffer.set_size(
+            &mut self.font_system,
+            Some(width as f32),
+            Some(height as f32),
+        );
         self.info_buffer
-            .set_size(&mut self.font_system, width as f32, height as f32);
-        self.info_buffer.shape_until_scroll(&mut self.font_system);
+            .shape_until_scroll(&mut self.font_system, true);
     }
 
     fn set_buffer_text(&mut self, buffer: BufferTarget, text: &str) {
@@ -252,7 +269,7 @@ impl TextRenderer {
             BufferTarget::Info => &mut self.info_buffer,
         };
 
-        buf.set_text(&mut self.font_system, text, attrs, Shaping::Advanced);
+        buf.set_text(&mut self.font_system, text, &attrs, Shaping::Advanced);
 
         if matches!(buffer, BufferTarget::Osd) {
             for line in buf.lines.iter_mut() {
@@ -260,7 +277,7 @@ impl TextRenderer {
             }
         }
 
-        buf.shape_until_scroll(&mut self.font_system);
+        buf.shape_until_scroll(&mut self.font_system, true);
     }
 
     pub fn set_text(&mut self, text: &str) {
@@ -299,6 +316,7 @@ impl TextRenderer {
         queue: &Queue,
         pass: &mut RenderPass<'a>,
     ) -> Result<()> {
+        let res = self.viewport.resolution();
         let mut text_areas = vec![
             TextArea {
                 buffer: &self.buffer,
@@ -308,10 +326,11 @@ impl TextRenderer {
                 bounds: TextBounds {
                     left: 0,
                     top: 0,
-                    right: self.viewport.width as i32,
-                    bottom: self.viewport.height as i32,
+                    right: res.width as i32,
+                    bottom: res.height as i32,
                 },
                 default_color: Color::rgb(255, 255, 255),
+                custom_glyphs: &[],
             },
             TextArea {
                 buffer: &self.osd_buffer,
@@ -321,10 +340,11 @@ impl TextRenderer {
                 bounds: TextBounds {
                     left: 0,
                     top: 0,
-                    right: self.viewport.width as i32,
-                    bottom: self.viewport.height as i32,
+                    right: res.width as i32,
+                    bottom: res.height as i32,
                 },
                 default_color: Color::rgb(255, 255, 255),
+                custom_glyphs: &[],
             },
         ];
 
@@ -339,10 +359,11 @@ impl TextRenderer {
                 bounds: TextBounds {
                     left: 0,
                     top: 0,
-                    right: self.viewport.width as i32,
-                    bottom: self.viewport.height as i32,
+                    right: res.width as i32,
+                    bottom: res.height as i32,
                 },
                 default_color: Color::rgb(255, 255, 255),
+                custom_glyphs: &[],
             });
         }
 
@@ -351,16 +372,13 @@ impl TextRenderer {
             queue,
             &mut self.font_system,
             &mut self.atlas,
-            Resolution {
-                width: self.viewport.width,
-                height: self.viewport.height,
-            },
+            &self.viewport,
             text_areas,
             &mut self.swash_cache,
         )?;
 
         self.text_renderer
-            .render(&self.atlas, pass)
+            .render(&self.atlas, &self.viewport, pass)
             .map_err(|e| anyhow::anyhow!(e))?;
         Ok(())
     }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -101,12 +101,14 @@ impl TransitionPipeline {
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "vs_main",
+                entry_point: Some("vs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "fragment",
+                entry_point: Some("fragment"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::REPLACE),
@@ -115,16 +117,13 @@ impl TransitionPipeline {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
                 front_face: wgpu::FrontFace::Ccw,
-                cull_mode: None,
-                unclipped_depth: false,
-                polygon_mode: wgpu::PolygonMode::Fill,
-                conservative: false,
+                ..Default::default()
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache: None,
         });
 
         let filter = match filter_mode {
@@ -188,7 +187,7 @@ impl TransitionPipeline {
     /// Pick a random transition mode from available effects
     pub fn random_mode() -> i32 {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
-        rng.gen_range(0..TRANSITION_MODE_COUNT)
+        let mut rng = rand::rng();
+        rng.random_range(0..TRANSITION_MODE_COUNT)
     }
 }


### PR DESCRIPTION
## Summary
- **wgpu** 0.19 → 25: migrate to new API (entry_point Option, PollType, TexelCopy*, DeviceDescriptor defaults)
- **glyphon** 0.5 → 0.9: new Cache/Viewport API, TextArea custom_glyphs field, Buffer API changes
- **rand** 0.8 → 0.9: thread_rng→rng, gen_range→random_range
- **winit**: remove `rwh_05` feature (wgpu 25 uses raw-window-handle 0.6 natively)

## Files changed
| File | Changes |
|------|---------|
| `Cargo.toml` | Version bumps for wgpu, glyphon, rand; remove winit rwh_05 feature |
| `src/transition.rs` | entry_point → Option, compilation_options, PrimitiveState defaults, rand API |
| `src/main.rs` | Instance::new ref, request_device args, RenderPassDescriptor defaults, resize API |
| `src/text.rs` | Major: Cache/Viewport, TextAtlas/prepare/render API, Buffer set_size/set_text/shape |
| `src/screenshot.rs` | Maintain→PollType, TexelCopy* renames |
| `src/image_loader.rs` | rand::rng(), TexelCopy* renames |

## Test plan
- [x] `cargo build` — zero errors, zero warnings
- [x] `cargo clippy` — clean
- [x] `cargo build --release` — clean
- [x] Manual testing: images, transitions, text rendering, screenshots, timer, color keys

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)