### PR TITLE
fix(ci): Resolve clippy result_large_err and format issues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -144,12 +144,11 @@ impl Config {
             }
         })?;
 
-        let config: Config = toml::from_str(&content).map_err(|e| {
-            SldshowError::ConfigParseError {
+        let config: Config =
+            toml::from_str(&content).map_err(|e| SldshowError::ConfigParseError {
                 path: path_ref.to_path_buf(),
-                source: e,
-            }
-        })?;
+                source: Box::new(e),
+            })?;
 
         config.validate()?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum SldshowError {
     ConfigParseError {
         path: Utf8PathBuf,
         #[source]
-        source: toml::de::Error,
+        source: Box<toml::de::Error>,
     },
 
     #[error("Invalid configuration: {0}")]


### PR DESCRIPTION
Boxes \	oml::de::Error\ in \SldshowError::ConfigParseError\ to fix \clippy::result_large_err\. Applies \cargo fmt\.