### PR TITLE
chore: add agent skills for issue-to-PR workflow and worktree management

### DIFF
--- a/.claude/skills/ultimate-issue-slayer/SKILL.md
+++ b/.claude/skills/ultimate-issue-slayer/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ultimate-issue-slayer
+description: >
+  End-to-end Issue-to-PR development workflow inside an isolated agent worktree.
+  Use this when asked to pick up a GitHub Issue, implement the fix or feature,
+  and open a pull request. This skill does NOT merge PRs.
+---
+
+# Ultimate Issue Slayer
+
+Run a complete Issue → PR flow inside a worktree managed by the `worktree-manager` skill.
+
+> **Boundary rule**: This skill never creates or deletes worktrees.
+> Worktree lifecycle is handled exclusively by `worktree-manager`.
+
+## 0. Pre-flight — Verify Worktree
+
+1. Check `Get-Location` and `git rev-parse --show-toplevel`.
+   - Expected path pattern: `.agent-worktrees/agent-<agent_id>-<task>`.
+2. If already inside an agent worktree → continue.
+3. If **not** inside a worktree → ask `worktree-manager` to create a temporary
+   `agent-<agent_id>-wip` worktree, then `cd` into it.
+4. Abort only if the user declines or the manager reports a collision.
+
+### Naming conventions
+
+| Element | Format | Example |
+|---------|--------|---------|
+| `agent_id` | `[a-zA-Z0-9]+` | `copilot01` |
+| Temporary branch | `agent-<agent_id>-wip` | `agent-copilot01-wip` |
+| Final branch | `agent-<agent_id>-<task>` | `agent-copilot01-issue-42` |
+| `<task>` | `[a-z0-9-]{1,32}` | `issue-42` |
+
+## 1. Issue Selection & Setup
+
+1. Find an unassigned issue: `gh issue list --assignee "" --state open`.
+2. Claim it immediately:
+   ```bash
+   gh issue edit <id> --add-assignee "@me"
+   gh issue comment <id> --body "Starting work (Agent: <agent_id>)"
+   ```
+3. If assignment fails (race condition), pick another issue.
+4. Create the final branch inside the worktree:
+   ```bash
+   git switch -c agent-<agent_id>-issue-<number>
+   ```
+
+## 2. Design & Planning
+
+1. Draft `implementation_plan.md` (scope, approach, acceptance criteria).
+2. **Wait for user review** before writing any code.
+
+## 3. Implementation
+
+- Prefer new modules under `src/`; keep `main.rs` changes minimal.
+- Follow the project's Conventional Commits format and coding standards
+  defined in `CONTRIBUTING.md` and `CLAUDE.md`.
+- Include co-author trailer when appropriate:
+  ```
+  Co-authored-by: GitHub Copilot <copilot@users.noreply.github.com>
+  ```
+
+## 4. Verification
+
+Run the full quality gate locally before pushing:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-features -- -D warnings
+cargo test --all-features
+cargo build --release
+```
+
+All four commands must pass. Do not push on failure.
+
+## 5. Pull Request
+
+1. Rebase onto `origin/main` and resolve any conflicts.
+2. Push the branch and open a PR:
+   - Title follows Conventional Commits (e.g., `feat: add ambient fit shader`).
+   - Body references the issue (`Closes #<number>`) and links to `implementation_plan.md`.
+3. **Do NOT merge.** Enter WAITING state and notify the user for review.

--- a/.claude/skills/worktree-manager/SKILL.md
+++ b/.claude/skills/worktree-manager/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: worktree-manager
+description: >
+  Create, list, and clean up isolated agent worktrees under `.agent-worktrees/`.
+  Use this when an agent needs a safe, isolated working directory.
+  This skill does NOT edit code or run tests.
+---
+
+# Worktree Manager
+
+Manage isolated git worktrees for AI agents under `.agent-worktrees/`.
+
+> **Boundary rule**: This skill only manages worktree directories.
+> It never edits source code, runs tests, or touches anything outside `.agent-worktrees/`.
+
+## 1. Create Worktree
+
+**Input**: `agent_id` (alphanumeric, e.g., `copilot01`)
+
+1. **Validate**: `agent_id` must match `[a-zA-Z0-9]+`.
+2. **Collision check**: If `.agent-worktrees/agent-<agent_id>-*` already exists, **abort**.
+   Do not reuse existing worktrees.
+3. **Create** the temporary worktree and branch:
+   ```bash
+   git worktree add .agent-worktrees/agent-<agent_id>-wip -b agent-<agent_id>-wip origin/main
+   ```
+4. After the agent selects an issue, it will create the final branch inside the worktree:
+   ```bash
+   git switch -c agent-<agent_id>-<task>
+   ```
+5. **Return** the absolute path to the new worktree.
+
+## 2. List Worktrees
+
+```bash
+git worktree list
+```
+
+## 3. Cleanup Worktree
+
+1. **Safety check**: Only delete if the branch is fully merged, or the user
+   explicitly requests force deletion.
+2. Remove the worktree:
+   ```bash
+   git worktree remove .agent-worktrees/agent-<agent_id>-<task>
+   ```
+3. Delete the branch:
+   ```bash
+   git branch -d agent-<agent_id>-<task>   # use -D only if force-requested
+   ```
+
+## Housekeeping
+
+Ensure `.agent-worktrees/README.md` exists with the following content:
+
+```
+This directory is managed by AI agents. Do not edit manually.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ Cargo.lock
 # Editor
 .vscode/
 .idea/
-.claude/
+.claude/*
+!.claude/skills/
 *.swp
 *.swo
 *~
@@ -32,3 +33,6 @@ nul
 !example.sldshow
 draft/
 issue_*.json
+
+# Worktrees
+.agent-worktrees/


### PR DESCRIPTION
## Summary

Add two Agent Skills under .claude/skills/ for AI agent workflows:

- **ultimate-issue-slayer**: End-to-end Issue→PR development flow inside isolated worktrees
- **worktree-manager**: Create, list, and clean up isolated agent worktrees

## Changes

- Add .claude/skills/ultimate-issue-slayer/SKILL.md
- Add .claude/skills/worktree-manager/SKILL.md
- Update .gitignore to track .claude/skills/ while ignoring other .claude/ files
- Skills rewritten from scratch following the [Agent Skills spec](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills):
  - Kebab-case directory and skill names
  - Concise YAML frontmatter with \
ame\ and \description\
  - Deduplicated content (references \CONTRIBUTING.md\/\CLAUDE.md\ instead of repeating)