### PR TITLE
chore: add agent:ready guardrail and team support to issue-slayer skill

### DIFF
--- a/.claude/agents/issue-slayer.md
+++ b/.claude/agents/issue-slayer.md
@@ -1,0 +1,47 @@
+---
+name: issue-slayer
+description: >
+  Autonomous issue implementer for sldshow2. Picks agent:ready issues,
+  implements in isolated worktree, opens PR. Works standalone or as team member.
+model: sonnet
+color: green
+memory: project
+---
+
+# Issue Slayer Agent
+
+You are a teammate on the sldshow2 project. Your job is to pick up GitHub issues
+and deliver pull requests.
+
+## Workflow
+
+Follow the **ultimate-issue-slayer** skill (`/.claude/skills/ultimate-issue-slayer/SKILL.md`)
+for the full step-by-step workflow. The skill covers:
+
+1. Issue selection (with `agent:ready` guardrail)
+2. Design & planning
+3. Implementation in an isolated worktree
+4. Verification (fmt, clippy, test, release build)
+5. Pull request creation
+6. Cleanup
+
+## Team Mode Behavior
+
+When spawned as a teammate via `Task` with a `team_name`:
+
+- **Issue assignment**: Check `TaskList` to see what issues other teammates are
+  working on. Avoid picking the same issue. If a specific issue is assigned to
+  you via `TaskUpdate`, work on that one.
+- **Plan approval**: Instead of `EnterPlanMode`, send your implementation plan
+  to the Team Lead via `SendMessage`. Wait for the Lead's approval message
+  before writing code.
+- **Progress updates**: After opening a PR, notify the Team Lead via
+  `SendMessage` with the PR URL.
+- **Cleanup**: Do not remove worktrees unless the Team Lead instructs you to.
+- **Conflict-prone files**: Minimize changes to `main.rs`, `Cargo.toml`, and
+  `config.rs`. Extract new functionality into dedicated modules under `src/`.
+
+## Standalone Mode
+
+When invoked directly (no team context), follow the skill as-is. Use
+`EnterPlanMode` for user approval and manage your own cleanup.

--- a/.claude/skills/ultimate-issue-slayer/SKILL.md
+++ b/.claude/skills/ultimate-issue-slayer/SKILL.md
@@ -10,6 +10,42 @@ description: >
 
 Run a complete Issue → PR flow inside an isolated git worktree.
 
+## Issue Selection Rules
+
+**Eligibility** — An issue may only be picked if ALL of the following are true:
+
+1. Has the `agent:ready` label
+2. State is `open`
+3. Not assigned to anyone (`no:assignee`)
+4. Does NOT have the `pending` label
+
+**Priority** — When multiple eligible issues exist, prefer in this order:
+
+1. `bug` over `enhancement`
+2. `phase:1` > `phase:2` > `phase:3`
+3. Lower issue number first
+
+**Prohibitions**:
+
+- **Never** pick an issue without the `agent:ready` label.
+- **Never** pick an issue that is already assigned.
+- One agent, one issue — do not work on multiple issues simultaneously.
+
+## Execution Mode
+
+This skill supports two execution patterns:
+
+**Pattern A (Standalone)**: Invoked directly by a user. Uses `EnterPlanMode`
+for user approval. The user drives cleanup decisions.
+
+**Pattern B (Team Member)**: Spawned by a Team Lead via `Task` with a
+`team_name`. Uses `SendMessage` to send plans to the Lead for approval.
+Cleanup requires Lead instruction.
+
+Detection: If you were spawned with a `team_name` or received a task
+assignment via `TaskList`/`TaskUpdate`, you are in Pattern B. Otherwise
+Pattern A.
+
 ## 0. Worktree Setup
 
 1. Determine the **main repo root** via `git rev-parse --show-toplevel`.
@@ -31,26 +67,33 @@ Run a complete Issue → PR flow inside an isolated git worktree.
 
 ## 1. Issue Selection & Setup
 
-1. If the user specifies an issue number, use that.
-   Otherwise, find unassigned open issues:
+1. Query eligible issues:
    ```bash
-   gh issue list --search "no:assignee state:open" --limit 20
+   gh issue list --label "agent:ready" --search "no:assignee state:open -label:pending" --json number,title,labels --limit 20
    ```
-   Present the list and let the user pick, or pick the highest-priority one if instructed.
-2. Claim the issue immediately:
+2. If the user specifies an issue number, verify it meets the eligibility
+   criteria above before proceeding.
+3. **Pattern A**: Present the ranked list to the user and let them choose.
+   **Pattern B**: Check `TaskList` to see what other teammates are working on.
+   Select the highest-priority eligible issue that no other teammate has
+   claimed. If a specific issue was assigned to you via `TaskUpdate`, use that.
+4. Claim the issue immediately:
    ```bash
    gh issue edit <N> --add-assignee "@me"
    gh issue comment <N> --body "Starting work on this issue."
    ```
-3. If assignment fails (race condition), pick another issue.
-4. Now proceed with worktree creation (step 0.3) using the issue details.
+5. If assignment fails (race condition), pick another issue.
+6. Now proceed with worktree creation (step 0.3) using the issue details.
 
 ## 2. Design (Plan Mode)
 
 1. Read the issue details, relevant source files, `CLAUDE.md`, and `CONTRIBUTING.md`.
-2. Use **EnterPlanMode** to design the implementation approach.
-   - Do **not** create an `implementation_plan.md` file. The plan lives in Claude Code's plan mode.
-3. Wait for user approval before writing any code.
+2. **Pattern A**: Use `EnterPlanMode` to design the implementation approach.
+   Wait for user approval before writing any code.
+   **Pattern B**: Draft the implementation plan and send it to the Team Lead
+   via `SendMessage`. Wait for the Lead's approval message before writing code.
+   - Do **not** create an `implementation_plan.md` file. The plan lives in
+     Claude Code's plan mode (Pattern A) or in the message exchange (Pattern B).
 
 ## 3. Implementation
 
@@ -59,6 +102,9 @@ Run a complete Issue → PR flow inside an isolated git worktree.
   defined in `CLAUDE.md` and `CONTRIBUTING.md`.
 - For co-author trailers in commit messages, refer to the **AI Co-Authorship**
   section in `CLAUDE.md` and use the appropriate trailer for the current agent.
+- **Team Note**: When working in Pattern B, minimize changes to conflict-prone
+  files (`main.rs`, `Cargo.toml`, `config.rs`). Extract new functionality into
+  dedicated modules. Keep diffs to shared files small and localized.
 
 ## 4. Verification
 
@@ -88,10 +134,12 @@ All four commands must pass. Do not push on failure.
    - Title follows Conventional Commits (e.g., `feat: add ambient fit shader`).
    - Body references the issue (`Closes #<N>`).
 3. **Do NOT merge.** Notify the user that the PR is ready for review.
+4. **Pattern B**: Send the PR URL to the Team Lead via `SendMessage`.
 
 ## 6. Cleanup (Optional)
 
-When the user requests cleanup after the PR is merged:
+When the user (Pattern A) or Team Lead (Pattern B) requests cleanup after the
+PR is merged:
 
 1. Return to the main repo root.
 2. Remove the worktree and branch:
@@ -100,3 +148,13 @@ When the user requests cleanup after the PR is merged:
    git branch -d <type>/issue-<N>-<description>
    ```
    Use `git branch -D` only if the user explicitly requests force deletion.
+3. **Pattern B**: Do not remove worktrees unless the Team Lead instructs you to.
+
+## Team Operation Flow (Reference)
+
+```
+1. Team Lead: TeamCreate → TaskCreate (per issue) → Task spawn (issue-slayer agent)
+2. Each Teammate: Issue claim → plan → Lead approval → implement → verify → PR
+3. Team Lead: Coordinate PR merge order → instruct agents to rebase if needed
+4. Team Lead: shutdown_request → TeamDelete
+```

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Cargo.lock
 .idea/
 .claude/*
 !.claude/skills/
+!.claude/agents/
 *.swp
 *.swo
 *~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,5 +77,29 @@ Multiple contributors may work on separate issues simultaneously. To minimize me
 - Pushing a tag like `v0.2.0` triggers the release workflow, which builds a Windows binary and creates a GitHub Release.
 - The tag must match the version in `Cargo.toml` — the CI verifies this.
 
+## AI Agent Workflow
+
+This project supports autonomous AI agent development using the `ultimate-issue-slayer` skill.
+
+### The `agent:ready` Label
+
+Issues must have the **`agent:ready`** label before an AI agent can pick them up. The full workflow is defined as a Claude Code Skill (`.claude/skills/ultimate-issue-slayer/SKILL.md`) and works with any agent that supports Claude Code Skills. This is an opt-in guardrail — maintainers explicitly approve issues for autonomous implementation by adding this label.
+
+**Eligibility criteria** — an agent may only work on an issue if ALL of:
+1. Has the `agent:ready` label
+2. Is open and unassigned
+3. Does not have a `pending` label
+
+**Priority** — when multiple eligible issues exist, agents prefer: `bug` > `enhancement`, then `phase:1` > `phase:2` > `phase:3`, then lowest issue number.
+
+### Execution Patterns
+
+| Pattern | How it runs | Plan approval | Use case |
+|---------|------------|---------------|----------|
+| **A (Standalone)** | User invokes the skill directly | `EnterPlanMode` → user approves | Single-issue work |
+| **B (Team)** | Team Lead spawns multiple agents | `SendMessage` → Lead approves | Parallel multi-issue sprint |
+
+Both patterns use isolated git worktrees (`.agent-worktrees/`) so work never touches the `main` branch directly. See `.claude/skills/ultimate-issue-slayer/SKILL.md` for the full workflow.
+
 ## Project Board
 Active issues and roadmap are tracked on the [GitHub Project](https://github.com/users/ugai/projects/1).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Default config location: `~/.sldshow`
 
 - **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, workflow, and coding standards.
 - **Architecture**: See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation and AI agent guidelines.
+- **AI Agent Automation**: Issues labeled `agent:ready` are picked up and slain by AI agents. See [CONTRIBUTING.md](CONTRIBUTING.md#ai-agent-workflow) for details.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add `agent:ready` GitHub label as opt-in gate — agents can only pick up issues with this label
- Rewrite `SKILL.md` with Issue Selection Rules (eligibility, priority, prohibitions) and dual execution mode (Pattern A: standalone, Pattern B: team)
- Create `.claude/agents/issue-slayer.md` for team-spawned agent definition
- Update `.gitignore` to track `.claude/agents/`
- Document AI agent workflow in CONTRIBUTING.md and README.md

## Test plan
- [x] `gh label list` confirms `agent:ready` label exists
- [x] Pre-commit hook passes (fmt, clippy, test)
- [x] `.claude/agents/issue-slayer.md` tracked by git
- [ ] Pattern A: manually invoke skill, verify `agent:ready`-less issues are excluded
- [ ] Pattern B: spawn 2 agents on non-conflicting issues, verify independent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)