### PR TITLE
fix: hide console window and embed application icon on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ windows = { version = "0.58", features = [
     "Win32_Foundation",
 ] }
 
+[target.'cfg(windows)'.build-dependencies]
+winresource = "0.1"
+
 # Optimize for fast compile times in dev
 [profile.dev]
 opt-level = 1

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,14 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    // Embed application icon and metadata into the Windows executable
+    #[cfg(windows)]
+    {
+        let mut res = winresource::WindowsResource::new();
+        res.set_icon("assets/icon/icon.ico");
+        res.compile().unwrap();
+    }
+
     // 1. Determine source assets directory
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let src_assets = Path::new(&manifest_dir).join("assets").join("fonts");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 //! Application entry point, event loop, and input handling.
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary
- Add `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` to hide the console window in release builds
- Add `winresource` build dependency to embed `assets/icon/icon.ico` into the executable
- Icon now appears in File Explorer, taskbar, and title bar

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)