### PR TITLE
chore: include agent/model identity in issue-slayer start comment

### DIFF
--- a/.claude/skills/ultimate-issue-slayer/SKILL.md
+++ b/.claude/skills/ultimate-issue-slayer/SKILL.md
@@ -80,8 +80,13 @@ Pattern A.
 4. Claim the issue immediately:
    ```bash
    gh issue edit <N> --add-assignee "@me"
-   gh issue comment <N> --body "Starting work on this issue."
+   gh issue comment <N> --body "🤖 Starting work on this issue.
+
+   Agent: **<agent-name>** | Model: **<model-name>** | Tool: **<tool-name>**"
    ```
+   - `<agent-name>` — The agent definition name (e.g., `issue-slayer`).
+   - `<model-name>` — The actual model powering this session (e.g., `Claude Sonnet 4.5`, `Claude Opus 4.6`). Determined from your system prompt.
+   - `<tool-name>` — The client tool (e.g., `Claude Code`).
 5. If assignment fails (race condition), pick another issue.
 6. Now proceed with worktree creation (step 0.3) using the issue details.
 


### PR DESCRIPTION
## Summary
- Issue Slayer がイシューに着手コメントを投稿する際、エージェント名・モデル名・ツール名を含めるようテンプレートを更新
- どのエージェントがどのモデルで作業しているか一目で分かるようになる

## Changes
- `.claude/skills/ultimate-issue-slayer/SKILL.md` — ステップ 1.4 のコメントテンプレートを拡張

## Example comment
```
🤖 Starting work on this issue.

Agent: **issue-slayer** | Model: **Claude Sonnet 4.5** | Tool: **Claude Code**
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)