### PR TITLE
fix: No Images Found Feedback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -918,7 +918,10 @@ impl ApplicationState {
 
         // Update filename bar (bottom-left) — persistent O or temporary o
         let show_bar = self.show_filename_text || self.filename_bar_temp_expiry.is_some();
-        if show_bar {
+
+        if self.texture_manager.len() == 0 {
+            self.text_renderer.set_text("No images found in path");
+        } else if show_bar {
             if let Some(path) = self.texture_manager.current_path() {
                 let filename = path.file_name().unwrap_or("Unknown");
                 let index = self.texture_manager.current_index + 1;
@@ -926,7 +929,8 @@ impl ApplicationState {
                 self.text_renderer
                     .set_text(&format!("{} [{}/{}]", filename, index, total));
             } else {
-                self.text_renderer.set_text("No images found");
+                // Should be unreachable if len > 0
+                self.text_renderer.set_text("");
             }
         } else {
             self.text_renderer.set_text("");


### PR DESCRIPTION
Closes #78

## Summary
Displays "No images found in path" message when the directory contains no valid images.

## Changes
- Modified `D:\git\sldshow2\.agent-worktrees\fix-issue-78-no-images-found-feedback\src\main.rs` to check if `texture_manager.len() == 0` before rendering filename bar
- Shows persistent error message instead of blank screen when no images are loaded
- Application continues to run normally without panicking

## Testing
- Verified with `cargo fmt --all -- --check` (passed)
- Verified with `cargo clippy --all-features -- -D warnings` (passed)
- Built successfully with `cargo build --release`

---

> Initially implemented by **Gemini 2.0 Pro** (Antigravity)
> Resumed and rebased by **Claude Opus 4.6** (Claude Code)