### PR TITLE
feat: add Ctrl+Shift+C to copy image to clipboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ No unit tests — testing is manual only.
 | `text.rs` | glyphon text rendering |
 | `config.rs` | TOML configuration (serde) |
 | `slideshow.rs` | Auto-advance timer |
+| `clipboard.rs` | Clipboard operations (copy image data) |
 
 ## Conventions
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,34 @@
+//! Clipboard operations for copying image data.
+
+use anyhow::{Context, Result};
+use arboard::{Clipboard, ImageData};
+use camino::Utf8Path;
+use std::borrow::Cow;
+
+/// Copies the image at the given path to the system clipboard.
+///
+/// Re-reads the image from disk to avoid holding large bitmaps in RAM.
+/// The image is converted to RGBA format for clipboard compatibility.
+pub fn copy_image_to_clipboard(path: &Utf8Path) -> Result<()> {
+    // Re-read from disk to save RAM
+    let img = image::open(path)
+        .with_context(|| format!("Failed to read image from {}", path))?
+        .to_rgba8();
+
+    let width = img.width() as usize;
+    let height = img.height() as usize;
+    let rgba_data = img.into_raw();
+
+    let image_data = ImageData {
+        width,
+        height,
+        bytes: Cow::Borrowed(&rgba_data),
+    };
+
+    let mut clipboard = Clipboard::new().context("Failed to access clipboard")?;
+    clipboard
+        .set_image(image_data)
+        .context("Failed to set clipboard image data")?;
+
+    Ok(())
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,6 +32,7 @@ pub enum InputAction {
     ToggleLoop,
     ToggleFitMode,
     SetWindowPosition { x: i32, y: i32 },
+    CopyImageToClipboard,
 }
 
 /// Input state tracker.
@@ -295,6 +296,11 @@ impl InputHandler {
             }
             PhysicalKey::Code(KeyCode::KeyL) => Some(InputAction::ToggleLoop),
             PhysicalKey::Code(KeyCode::KeyA) => Some(InputAction::ToggleFitMode),
+            PhysicalKey::Code(KeyCode::KeyC)
+                if modifiers.control_key() && modifiers.shift_key() =>
+            {
+                Some(InputAction::CopyImageToClipboard)
+            }
             _ => None,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use winit::{
     window::WindowBuilder,
 };
 
+mod clipboard;
 mod config;
 mod drag_drop;
 mod error;
@@ -460,6 +461,24 @@ impl ApplicationState {
             InputAction::SetWindowPosition { x, y } => {
                 self.window
                     .set_outer_position(winit::dpi::PhysicalPosition::new(x, y));
+            }
+            InputAction::CopyImageToClipboard => {
+                if self.texture_manager.paths.is_empty() {
+                    self.show_osd("No Image Loaded".to_string());
+                } else {
+                    let current_path =
+                        &self.texture_manager.paths[self.texture_manager.current_index];
+                    match clipboard::copy_image_to_clipboard(current_path) {
+                        Ok(_) => {
+                            info!("Copied image to clipboard: {}", current_path);
+                            self.show_osd("Copied Image to Clipboard".to_string());
+                        }
+                        Err(e) => {
+                            error!("Failed to copy image to clipboard: {}", e);
+                            self.show_osd(format!("Copy Failed: {}", e));
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #77

## Summary
- Add `Ctrl+Shift+C` hotkey to copy the current image bitmap to clipboard
- Users can paste into other apps (Discord, Paint, image editors, etc.)
- OSD shows confirmation "Copied Image to Clipboard"
- Error handling for clipboard busy/file read/decode failures

## Implementation
- **New module**: `src/clipboard.rs` - Re-reads image from disk to avoid RAM overhead
- **InputAction**: Added `CopyImageToClipboard` variant
- **Keybinding**: `Ctrl+Shift+C` handler in `InputHandler::handle_keyboard_pressed()`
- **Integration**: Handler in `ApplicationState::execute_input_action()`
- Uses existing `arboard` dependency (already in `Cargo.toml`)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes
- [x] `cargo build --release` succeeds
- [ ] Manual test: Press `Ctrl+Shift+C` → verify OSD → paste into Paint/Discord
- [ ] Test with no images loaded → verify "No Image Loaded" OSD
- [ ] Test clipboard busy scenario (if possible)

🤖 Generated with Claude Code