### PR TITLE
feat: add keyboard shortcut help overlay with ? key

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -33,6 +33,7 @@ pub enum InputAction {
     ToggleFitMode,
     SetWindowPosition { x: i32, y: i32 },
     CopyImageToClipboard,
+    ToggleHelpOverlay,
 }
 
 /// Input state tracker.
@@ -300,6 +301,9 @@ impl InputHandler {
                 if modifiers.control_key() && modifiers.shift_key() =>
             {
                 Some(InputAction::CopyImageToClipboard)
+            }
+            PhysicalKey::Code(KeyCode::Slash) if modifiers.shift_key() => {
+                Some(InputAction::ToggleHelpOverlay)
             }
             _ => None,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,6 +480,9 @@ impl ApplicationState {
                     }
                 }
             }
+            InputAction::ToggleHelpOverlay => {
+                self.egui_overlay.toggle_help_overlay();
+            }
         }
     }
 
@@ -982,13 +985,28 @@ impl ApplicationHandler for ApplicationState {
         let modifiers = self.modifiers;
         if !egui_consumed && !self.input(&event, &modifiers) {
             match event {
-                WindowEvent::CloseRequested
-                | WindowEvent::KeyboardInput {
+                WindowEvent::CloseRequested => event_loop.exit(),
+                WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
                             state: ElementState::Pressed,
-                            physical_key:
-                                PhysicalKey::Code(KeyCode::Escape) | PhysicalKey::Code(KeyCode::KeyQ),
+                            physical_key: PhysicalKey::Code(KeyCode::Escape),
+                            ..
+                        },
+                    ..
+                } => {
+                    // Close help overlay if visible, otherwise exit
+                    if self.egui_overlay.help_overlay_visible() {
+                        self.egui_overlay.toggle_help_overlay();
+                    } else {
+                        event_loop.exit();
+                    }
+                }
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            physical_key: PhysicalKey::Code(KeyCode::KeyQ),
                             ..
                         },
                     ..

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -24,6 +24,9 @@ pub struct EguiOverlay {
     // Info overlay toggle state
     show_info_overlay: bool,
 
+    // Help overlay toggle state
+    show_help_overlay: bool,
+
     // Style settings
     font_size: f32,
     text_color: Color32,
@@ -57,6 +60,7 @@ impl EguiOverlay {
             osd_text: String::new(),
             info_text: String::new(),
             show_info_overlay: false,
+            show_help_overlay: false,
             font_size: 20.0,
             text_color: Color32::WHITE,
         }
@@ -97,6 +101,17 @@ impl EguiOverlay {
     /// Check if info overlay is visible
     pub fn info_overlay_visible(&self) -> bool {
         self.show_info_overlay
+    }
+
+    /// Toggle help overlay visibility
+    pub fn toggle_help_overlay(&mut self) -> bool {
+        self.show_help_overlay = !self.show_help_overlay;
+        self.show_help_overlay
+    }
+
+    /// Check if help overlay is visible
+    pub fn help_overlay_visible(&self) -> bool {
+        self.show_help_overlay
     }
 
     /// Forward winit events to egui
@@ -171,6 +186,67 @@ impl EguiOverlay {
                                 .color(self.text_color),
                         );
                     });
+                });
+        }
+
+        // Help overlay (centered window)
+        if self.show_help_overlay {
+            egui::Window::new("Keyboard Shortcuts")
+                .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
+                .collapsible(false)
+                .resizable(false)
+                .show(&self.context, |ui| {
+                    ui.set_min_width(500.0);
+
+                    ui.heading("Navigation");
+                    ui.label("Space / Right       Next image");
+                    ui.label("Left               Previous image");
+                    ui.label("Shift+Left/Right   Skip 10 images");
+                    ui.label("Home / End         Jump to first/last image");
+                    ui.label("Mouse Wheel        Next/previous image");
+                    ui.label("Shift + Wheel      Skip 10 images");
+                    ui.label("Left Click         Next image");
+                    ui.label("Right Click        Previous image");
+                    ui.label("Double Click       Toggle fullscreen");
+                    ui.label("Drag Window        Move window position");
+
+                    ui.add_space(10.0);
+                    ui.heading("Playback");
+                    ui.label("P                  Pause/resume slideshow");
+                    ui.label("[ / ]              Adjust timer (-/+ 1s)");
+                    ui.label("Shift + [ / ]      Adjust timer (-/+ 60s)");
+                    ui.label("Backspace          Reset timer to default");
+                    ui.label("L                  Toggle loop mode");
+
+                    ui.add_space(10.0);
+                    ui.heading("Display");
+                    ui.label("F                  Toggle fullscreen");
+                    ui.label("D                  Toggle window decorations");
+                    ui.label("T                  Toggle always on top");
+                    ui.label("A                  Toggle fit mode (Normal/Ambient)");
+                    ui.label("I / Shift+I        Show info temporarily / toggle");
+                    ui.label("O / Shift+O        Show filename temporarily / toggle");
+
+                    ui.add_space(10.0);
+                    ui.heading("Color Adjustments");
+                    ui.label("1 / 2              Brightness -/+");
+                    ui.label("3 / 4              Contrast -/+");
+                    ui.label("5 / 6              Gamma -/+");
+                    ui.label("7 / 8              Saturation -/+");
+
+                    ui.add_space(10.0);
+                    ui.heading("Actions");
+                    ui.label("S                  Take screenshot");
+                    ui.label("Ctrl+Shift+C       Copy image to clipboard");
+                    ui.label("?                  Toggle this help");
+                    ui.label("Escape             Close this help");
+
+                    ui.add_space(10.0);
+                    ui.label(
+                        RichText::new("Press ? or Escape to close")
+                            .italics()
+                            .color(Color32::GRAY),
+                    );
                 });
         }
     }


### PR DESCRIPTION
Closes #43

## Summary
- Adds a keyboard shortcut help overlay that displays all available keyboard shortcuts
- Toggle with `?` key (Shift+Slash)
- Close with `Escape` or `?` again
- Uses egui Window centered on screen with comprehensive shortcut list

## Implementation
- Added `ToggleHelpOverlay` action to `InputAction` enum in `input.rs`
- Implemented help overlay rendering in `overlay.rs` using `egui::Window`
- Modified `Escape` key handling in `main.rs` to close help overlay before exiting app
- Organized shortcuts into categories: Navigation, Playback, Display, Color Adjustments, Actions

## Testing
✅ `cargo fmt --all -- --check`
✅ `cargo clippy --all-features -- -D warnings`
✅ `cargo test --all-features`
✅ `cargo build --release`

## Manual Test
To test manually, run:
```
cd D:/git/sldshow2/.agent-worktrees/feat-issue-43-help-overlay
cargo run --release -- example.sldshow
```
Press `?` to toggle the help overlay.

🤖 Generated with Claude Code