### PR TITLE
chore: migrate label system from phase-based to priority-based

### DIFF
--- a/.claude/skills/guild-quest-receptionist/SKILL.md
+++ b/.claude/skills/guild-quest-receptionist/SKILL.md
@@ -181,8 +181,8 @@ Apply these labels as appropriate:
 - **Always**: `agent:proposed` — marks the issue as AI-generated. This is
   required on every quest posted by this skill.
 - **Type**: `enhancement` or `bug`
-- **Phase**: `phase:1` (quick wins, foundation), `phase:2` (core enhancements),
-  or `phase:3` (advanced/experimental)
+- **Priority** (optional): `priority:p0` (critical), `priority:p1` (high),
+  `priority:p2` (normal), or `priority:p3` (low). Omit if unsure — no label = `p2`
 - **Do NOT add `agent:ready`** — the guild master (maintainer) reviews and
   approves quests for Slayer pickup by adding this label personally.
 
@@ -205,8 +205,8 @@ After posting all quests, output a summary:
 
 | # | Title | Labels | Perspective |
 |---|-------|--------|-------------|
-| 80 | feat: ... | enhancement, phase:1 | UX |
-| 81 | fix: ... | bug, phase:1 | Robustness |
+| 80 | feat: ... | enhancement, priority:p2 | UX |
+| 81 | fix: ... | bug, priority:p1 | Robustness |
 ...
 
 Total: N quests posted
@@ -229,4 +229,4 @@ Skipped: M ideas (duplicates or out of scope)
   Write it directly into the body text — do not rely on shell variable
   expansion.
 - **Respect the roadmap** — do not contradict or duplicate the guild's
-  existing quest plans (open issues, phase labels).
+  existing quest plans (open issues, priority labels).

--- a/.claude/skills/ultimate-issue-slayer/SKILL.md
+++ b/.claude/skills/ultimate-issue-slayer/SKILL.md
@@ -22,7 +22,7 @@ Run a complete Issue → PR flow inside an isolated git worktree.
 **Priority** — When multiple eligible issues exist, prefer in this order:
 
 1. `bug` over `enhancement`
-2. `phase:1` > `phase:2` > `phase:3`
+2. `priority:p0` > `priority:p1` > `priority:p2` > `priority:p3` (no label = `p2`)
 3. Lower issue number first
 
 **Prohibitions**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,16 @@ Multiple contributors may work on separate issues simultaneously. To minimize me
 - Pushing a tag like `v0.2.0` triggers the release workflow, which builds a Windows binary and creates a GitHub Release.
 - The tag must match the version in `Cargo.toml` — the CI verifies this.
 
+## Labels
+
+Issues use three label categories:
+
+| Category | Labels | Notes |
+| :--- | :--- | :--- |
+| **Priority** | `priority:p0` `priority:p1` `priority:p2` `priority:p3` | No label = `p2` (normal). Color-coded by severity |
+| **Agent** | `agent:ready` `agent:proposed` | See [docs/AGENTS.md](docs/AGENTS.md) |
+| **Type** | `bug` `enhancement` `refactor` `documentation` `good first issue` `help wanted` … | Standard GitHub types |
+
 ## AI Agent Workflow
 
 This project supports autonomous AI agent development using the `ultimate-issue-slayer` skill.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,10 +2,19 @@
 
 `sldshow2` supports autonomous development using AI Agents (like adding a co-pilot to your team). This document defines the rules of engagement.
 
-## The `agent:ready` Label
+## Labels
+
+### `agent:ready`
 
 Issues must have the **`agent:ready`** label before an AI agent can pick them up.
 This is an opt-in guardrail — maintainers explicitly approve issues for autonomous implementation by adding this label.
+
+### `agent:proposed`
+
+Issues with **`agent:proposed`** were opened by the `guild-quest-receptionist` skill.
+They are **not yet approved** for autonomous implementation. Agents must wait until a maintainer adds `agent:ready` before picking them up.
+
+> **Note**: `agent:proposed` is an origin label, not a status. It stays on the issue even after `agent:ready` is added, so you can always filter AI-proposed issues with `--label agent:proposed`.
 
 ### Eligibility Criteria
 An agent may only work on an issue if **ALL** of the following are true:
@@ -17,7 +26,7 @@ An agent may only work on an issue if **ALL** of the following are true:
 ### Priority
 When multiple eligible issues exist, agents favor:
 1.  `bug` > `enhancement`
-2.  `phase:1` > `phase:2` > `phase:3`
+2.  `priority:p0` > `priority:p1` > `priority:p2` > `priority:p3` (no label = `p2`)
 3.  Lowest issue number
 
 ## Execution Patterns


### PR DESCRIPTION
## Summary

- Replace `phase:1/2/3` labels with `priority:p0/p1/p2/p3` across all docs and agent skills
- Add Labels section to `CONTRIBUTING.md`
- Document `agent:proposed` as an origin label in `docs/AGENTS.md`
- Unify label colors by category (red gradient for priority, purple for agent, blue for features, grey for admin, green for community)

Ref #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)