### PR TITLE
fix: apply config.window.fullscreen at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ fn main() -> Result<()> {
     };
 
     let transparent = config.style.bg_color[3] < 255;
+    let fullscreen = config
+        .window
+        .fullscreen
+        .then_some(winit::window::Fullscreen::Borderless(None));
     let window_attributes = winit::window::Window::default_attributes()
         .with_title("sldshow2")
         .with_inner_size(winit::dpi::LogicalSize::new(
@@ -74,7 +78,8 @@ fn main() -> Result<()> {
         ))
         .with_decorations(config.window.decorations)
         .with_resizable(config.window.resizable)
-        .with_transparent(transparent);
+        .with_transparent(transparent)
+        .with_fullscreen(fullscreen);
 
     #[allow(deprecated)]
     let window = Arc::new(event_loop.create_window(window_attributes).unwrap());


### PR DESCRIPTION
## Summary

- Pass `Fullscreen::Borderless(None)` to `window_attributes` when `config.window.fullscreen` is `true`
- Previously the `fullscreen` config field was parsed but never applied to the window at creation time

## Test plan

- [x] Set `fullscreen = true` in your `sldshow2.toml` config and launch — window should open in borderless fullscreen
- [x] Set `fullscreen = false` (or omit the key) — window should open in windowed mode at the configured size
- [x] All existing unit tests pass

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)