### PR TITLE
fix: reset_timer() uses config's original timer value instead of hardcoded 3.0s

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -77,6 +77,9 @@ pub struct ApplicationState {
 
     // Input state
     modifiers: winit::keyboard::ModifiersState,
+
+    // Timer reset target — stores the config's original timer value
+    initial_timer: f32,
 }
 
 struct ActiveTransition {
@@ -246,6 +249,7 @@ impl ApplicationState {
         };
 
         let shuffle_enabled = config.viewer.shuffle;
+        let initial_timer = config.viewer.timer;
 
         let state = Self {
             surface,
@@ -279,6 +283,7 @@ impl ApplicationState {
             drag_drop,
             shuffle_enabled,
             modifiers: winit::keyboard::ModifiersState::default(),
+            initial_timer,
         };
 
         state.update_window_title();
@@ -625,7 +630,7 @@ impl ApplicationState {
     }
 
     fn reset_timer(&mut self) {
-        let default = 3.0; // Hardcoded default since config tracks current
+        let default = self.initial_timer;
         self.slideshow.set_duration(default);
         self.config.viewer.timer = default; // Sync to config
         info!("Slideshow timer reset to: {:.1}s", default);


### PR DESCRIPTION
## Summary

`reset_timer()` in `src/app.rs` previously reset the slideshow timer to a hardcoded `3.0` seconds regardless of what the user configured. This meant pressing `Backspace` would always set the timer to 3.0s, even if `timer = 30.0` was set in the config.

## Fix

- Added `initial_timer: f32` field to `ApplicationState`, initialized from `config.viewer.timer` at startup
- `reset_timer()` now uses `self.initial_timer` instead of the hardcoded `3.0`

Only `src/app.rs` was changed. The diff is 6 lines.

## Manual Test

```
cargo run --release -- test.sldshow
```

1. Set `timer = 30.0` in your config
2. Press `[` / `]` to adjust the timer
3. Press `Backspace` — timer should reset to **30.0s**, not 3.0s

Closes #121