### PR TITLE
fix: warn when non-UTF-8 paths are skipped during directory scan

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -466,14 +466,20 @@ fn scan_directory_recursive_parallel(
         .flat_map_iter(|entry| {
             let path = entry.path();
             if path.is_file() && is_supported_image(&path) {
-                match Utf8PathBuf::try_from(path) {
+                match Utf8PathBuf::try_from(path.clone()) {
                     Ok(utf8_path) => vec![utf8_path].into_iter(),
-                    Err(_) => vec![].into_iter(),
+                    Err(_) => {
+                        warn!("skipping non-UTF-8 path: {:?}", path);
+                        vec![].into_iter()
+                    }
                 }
             } else if path.is_dir() && recursive {
                 match scan_directory_recursive_parallel(&path, recursive, depth + 1) {
                     Ok(subdir_paths) => subdir_paths.into_iter(),
-                    Err(_) => vec![].into_iter(),
+                    Err(e) => {
+                        warn!("failed to scan directory {:?}: {}", path, e);
+                        vec![].into_iter()
+                    }
                 }
             } else {
                 vec![].into_iter()


### PR DESCRIPTION
## Summary

- Add `warn!` log call when `Utf8PathBuf::try_from()` fails for a non-UTF-8 image file path
- Add `warn!` log call when recursive subdirectory scan fails for a non-UTF-8 directory path
- Previously both failure arms silently returned an empty iterator with no diagnostic output

## Test plan

- [x] Build passes: `cargo build`
- [x] Clippy clean: `cargo clippy --all-features -- -D warnings`
- [x] Tests pass: `cargo test`
- [x] Manual: run with `cargo run --release -- test.sldshow` and verify normal operation unaffected

Closes #122