### PR TITLE
fix: use configured interval for timer adjustment when paused

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -603,7 +603,7 @@ impl ApplicationState {
     }
 
     fn timer_step(&self, increasing: bool) -> f32 {
-        let current = self.slideshow.duration();
+        let current = self.slideshow.interval_secs();
         if increasing && current < 5.0 || !increasing && current <= 5.0 {
             1.0
         } else {
@@ -612,7 +612,7 @@ impl ApplicationState {
     }
 
     fn adjust_timer(&mut self, delta: f32) {
-        let new_timer = (self.slideshow.duration() + delta).round().max(0.0);
+        let new_timer = (self.slideshow.interval_secs() + delta).round().max(0.0);
         self.slideshow.set_duration(new_timer);
         self.config.viewer.timer = new_timer; // Sync to config
         if new_timer <= 0.0 {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -54,12 +54,9 @@ impl SlideshowTimer {
         }
     }
 
-    pub fn duration(&self) -> f32 {
-        if self.paused {
-            0.0
-        } else {
-            self.interval.as_secs_f32()
-        }
+    /// Returns the configured interval in seconds regardless of pause state.
+    pub fn interval_secs(&self) -> f32 {
+        self.interval.as_secs_f32()
     }
 }
 


### PR DESCRIPTION
## Summary

- `SlideshowTimer::duration()` returned `0.0` when paused, so pressing `]` while paused always set the timer to `1.0` instead of incrementing from the actual configured value
- Removed the buggy `duration()` method and replaced with `interval_secs()`, which always returns `self.interval.as_secs_f32()` regardless of pause state
- Updated `timer_step()` and `adjust_timer()` in `app.rs` to use `interval_secs()`

## Test plan

- [x] Start slideshow with a timer > 1s (e.g. 10s)
- [x] Press `Space` to pause
- [x] Press `]` to increase — timer should show 11s (not 1s)
- [x] Press `[` to decrease — timer should show 9s (not 0s/paused)
- [x] Unpause and confirm the new timer value is used

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)