### PR TITLE
feat: add dispatching-guild-expedition skill for full-pipeline sprint

### DIFF
--- a/.claude/skills/dispatching-guild-expedition/SKILL.md
+++ b/.claude/skills/dispatching-guild-expedition/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: dispatching-guild-expedition
+description: >
+  Orchestrates a full sprint: Rangers scout in parallel, user approves issues,
+  Raid Commander detects conflicts, then Slayers implement in parallel.
+  Use for a complete autonomous development cycle from issue discovery to open
+  PRs. Does NOT merge PRs.
+---
+
+# Dispatching Guild Expedition
+
+Full pipeline: Scout → Approve → Analyze → Implement.
+
+## Step 0 — Focus Confirmation
+
+Before spawning anything, ask the user one question:
+
+> "Which perspectives should Rangers focus on? (Leave blank for defaults)"
+
+The six perspectives from RECON.md, in priority order:
+
+1. Robustness & Error Handling
+2. Code Quality & Architecture
+3. Performance
+4. User Experience
+5. Cross-Platform & Compatibility
+6. New Features (small scope only)
+
+**Default split across 4 Rangers:**
+
+| Ranger | Perspectives |
+|--------|-------------|
+| ranger-1 | 1 — Robustness & Error Handling |
+| ranger-2 | 2 — Code Quality & Architecture |
+| ranger-3 | 3 — Performance + 4 — User Experience |
+| ranger-4 | 5 — Cross-Platform + 6 — New Features |
+
+If the user specifies different focuses, redistribute accordingly.
+
+## Step 1 — Scout (Ranger × 4, parallel)
+
+Create a team. Spawn 4 `issue-ranger` agents in **Pattern B** (Team Member mode).
+Pass each agent's assigned perspective(s) in their task prompt:
+
+> "Scout from these perspectives only: [list]. Run as Pattern B — send your
+> vetted candidate list to the Team Lead (me) before posting anything."
+
+Wait until all 4 Rangers have reported their candidate lists.
+
+## Step 2 — Aggregate & Approve
+
+Collect the 4 reports. Before showing the user:
+
+- **Deduplicate**: same underlying problem from multiple Rangers → keep the
+  best-scoped version; notify the relevant Ranger(s) to drop duplicates.
+- **Merge**: near-identical candidates → combine into one issue.
+
+Present the consolidated list to the user with `AskUserQuestion`
+(`multiSelect: true`). Each option: `[Ranger] title — one-line summary`.
+
+Based on the user's selection:
+1. Tell each Ranger which issues to post and which to skip.
+2. Ask the user which posted issues should receive `agent:ready` immediately,
+   or handle it as part of the ranger Ready Seal step.
+
+Wait for all Rangers to confirm posting before proceeding.
+
+## Step 3 — Analyze (Raid Commander)
+
+Spawn an `issue-raid-commander` agent as a subagent via the Task tool.
+Pass it the current `agent:ready` queue. Present its conflict analysis
+output to the user.
+
+If the queue is empty (no `agent:ready` issues), skip to summary and stop.
+
+## Step 4 — Implement (Slayer × N)
+
+Spawn `issue-slayer` agents based on the Raid Commander's sprint plan:
+
+- **Non-conflicting issues**: spawn all in parallel, up to 8 agents.
+- **Conflicting groups**: spawn in Raid Commander's recommended serial order —
+  wait for each PR to open before spawning the next in the chain.
+
+All Slayers run in **Pattern B** (Team Member mode). Coordinate merge order
+per the Raid Commander's analysis. When all Slayers have opened their PRs,
+shut down the team and report the sprint summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ issue-slayer × N      Implement in parallel worktrees → open PRs
 Run `issue-raid-commander` before spawning a slayer team to avoid merge conflicts.
 For single-issue work, skip it and go straight to `issue-slayer`.
 
+**Full pipeline shortcut**: `dispatching-guild-expedition` runs the entire
+workflow above in one command — Rangers × 4, user approval gate, Commander,
+then Slayers × N in parallel.
+
 ## Execution Patterns
 
 We use two primary patterns for agent work, both utilizing isolated `git worktree`s to avoid messing with your main branch.
@@ -99,6 +103,12 @@ Reads the ready queue, detects merge conflicts before they happen, and
 hands the team lead a sprint plan.
 Once fought on the front lines. Now stands behind them.
 Never spawns agents. Only assesses. Never intervenes.
+</td>
+<td align="center" width="50%">
+<strong><code>dispatching-guild-expedition</code></strong> — <em>One Command. Full Sprint.</em><br>
+Orchestrates the entire pipeline: Rangers × 4 scout in parallel, the user
+approves issues at the gate, Raid Commander maps the battlefield, then
+Slayers × N charge in parallel. From empty board to open PRs.
 </td>
 </tr>
 </table>


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/dispatching-guild-expedition/SKILL.md` — a shallow orchestration skill that chains the full agent workflow in one command: Rangers × 4 (parallel scouting) → user approval gate → Raid Commander (conflict analysis) → Slayers × N (parallel implementation)
- Updates `AGENTS.md`: adds the skill to the Recommended Workflow section and the Skills table

## Notes

- Single `SKILL.md` file only — no duplicated logic; each phase delegates to the existing sub-skills (`issue-ranger`, `issue-raid-commander`, `issue-slayer`)
- Follows skill authoring best practices: third-person description, gerund naming, under 500 lines, consistent terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)