### PR TITLE
fix: correct shader comment from 22 to 20 transition effects

### DIFF
--- a/assets/shaders/transition.wgsl
+++ b/assets/shaders/transition.wgsl
@@ -1,6 +1,6 @@
 // Transition shader for sldshow2
 // Ported from original sldshow with updated WGSL syntax
-// 22 different transition effects
+// 20 different transition effects
 
 // Vertex output structure
 struct VertexOutput {


### PR DESCRIPTION
## Summary

- Corrects the comment in `assets/shaders/transition.wgsl` to say 20 transition effects instead of 22

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-sonnet-4-6 (Claude Code) <noreply@anthropic.com>