### PR TITLE
fix: replace unwrap() on EventLoop/Window creation with context()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 //! Application entry point.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use log::{error, warn};
 use std::sync::Arc;
@@ -56,12 +56,13 @@ fn main() -> Result<()> {
             EventLoop::builder()
                 .with_msg_hook(drag_drop::build_msg_hook(drag_drop_tx))
                 .build()
-                .unwrap()
+                .context("Failed to create event loop")?
         }
         #[cfg(not(windows))]
         {
             drop(drag_drop_tx); // suppress unused-variable on non-Windows
-            EventLoop::new().unwrap()
+            EventLoop::new()
+                .context("Failed to create event loop — is a display server running?")?
         }
     };
 
@@ -87,7 +88,11 @@ fn main() -> Result<()> {
         .with_fullscreen(fullscreen);
 
     #[allow(deprecated)]
-    let window = Arc::new(event_loop.create_window(window_attributes).unwrap());
+    let window = Arc::new(
+        event_loop
+            .create_window(window_attributes)
+            .context("Failed to create window")?,
+    );
 
     // Replace winit's OLE drag-and-drop with WM_DROPFILES
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- Replace `.unwrap()` on `EventLoop::build()`, `EventLoop::new()`, and `event_loop.create_window()` with `.context(...)?`
- Provides meaningful error messages instead of opaque panics when display server is unavailable

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-sonnet-4-6 (Claude Code) <noreply@anthropic.com>