### PR TITLE
fix: catch panics in image loader threads to prevent slot leaks

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -288,7 +288,18 @@ impl TextureManager {
                     self.loading_tasks.insert(idx);
 
                     std::thread::spawn(move || {
-                        let res = load_image_rgba(&path, max_size);
+                        let res = std::panic::catch_unwind(|| load_image_rgba(&path, max_size))
+                            .unwrap_or_else(|payload| {
+                                let msg = if let Some(s) = payload.downcast_ref::<String>() {
+                                    s.clone()
+                                } else if let Some(s) = payload.downcast_ref::<&str>() {
+                                    (*s).to_owned()
+                                } else {
+                                    "unknown panic in image loader thread".to_owned()
+                                };
+                                error!("Image loader thread panicked for index {}: {}", idx, msg);
+                                Err(anyhow::anyhow!("loader thread panicked: {}", msg))
+                            });
                         if tx.send((idx, res)).is_err() {
                             warn!("Failed to send loaded image {} (receiver dropped)", idx);
                         }


### PR DESCRIPTION
## Summary

- Wrap `load_image_rgba` in `std::panic::catch_unwind` so panics in loader threads return `Err` rather than leaving `loading_tasks` slots permanently occupied
- Logs the panic message at `error!` level with the image index for diagnostics

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-sonnet-4-6 (Claude Code) <noreply@anthropic.com>