### PR TITLE
docs: add verify-sprint skill for batch PR verification workflow

### DIFF
--- a/.claude/skills/dispatching-guild-expedition/SKILL.md
+++ b/.claude/skills/dispatching-guild-expedition/SKILL.md
@@ -84,3 +84,5 @@ Spawn `issue-slayer` agents based on the Raid Commander's sprint plan:
 All Slayers run in **Pattern B** (Team Member mode). Coordinate merge order
 per the Raid Commander's analysis. When all Slayers have opened their PRs,
 shut down the team and report the sprint summary.
+
+Suggest using `verify-sprint` to batch-verify and squash-merge the opened PRs.

--- a/.claude/skills/verify-sprint/SKILL.md
+++ b/.claude/skills/verify-sprint/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: verify-sprint
+description: >
+  Batch-verifies multiple sprint PR branches by merging them into a local
+  ephemeral verify branch and running a combined visual check before
+  squash-merging each PR into main. The verify branch is never pushed to
+  remote. Use after a sprint where multiple issue-slayer agents have opened
+  PRs, or whenever the user wants to verify several PRs together before merging.
+---
+
+# Verify Sprint
+
+## Workflow checklist
+
+Copy and track progress:
+
+```
+- [ ] Step 1: Identify PR branches
+- [ ] Step 2: Fetch and create verify branch
+- [ ] Step 3: Merge all PR branches
+- [ ] Step 4: Visual verification (user)
+- [ ] Step 5: Merge PRs into main
+- [ ] Step 6: Discard verify branch
+```
+
+## Step 1 — Identify PR Branches
+
+If the user hasn't provided PR numbers, list open PRs:
+
+```bash
+gh pr list --state open --json number,title,headRefName
+```
+
+Confirm with the user which PRs to include.
+
+## Step 2 — Fetch and Create Verify Branch
+
+**NEVER push this branch to remote.**
+
+```bash
+git fetch origin
+git checkout -b verify/sprint-$(date +%Y-%m-%d) main
+```
+
+If the branch name already exists, append `-2`, `-3`, etc.
+
+## Step 3 — Merge All PR Branches
+
+```bash
+git merge origin/<branch-1> origin/<branch-2> origin/<branch-3> ...
+```
+
+If the octopus merge fails due to conflicts, fall back to sequential merges.
+Report any conflicts to the user before proceeding.
+
+## Step 4 — Visual Verification
+
+Tell the user to run:
+
+```bash
+cargo run --release -- test.sldshow
+```
+
+Ask: *"Visual check complete — did everything look correct? (yes / issue found)"*
+
+**If an issue is found:**
+
+1. Identify the PR branch responsible.
+2. User or agent adds fix commits to that branch.
+3. Re-merge and re-check:
+
+```bash
+git merge origin/<fixed-branch>
+# → user runs cargo run --release again
+```
+
+Repeat until the user confirms no issues.
+
+## Step 5 — Merge PRs into Main
+
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+Use the Raid Commander's recommended order if available; otherwise merge fixes
+before features that depend on them.
+
+## Step 6 — Discard Verify Branch
+
+```bash
+git checkout main
+git branch -D verify/sprint-<date>
+git pull origin main
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ issue-ranger          Scout the codebase → post agent:proposed issues
 issue-raid-commander  Analyze ready queue → detect conflicts → output sprint plan
       ↓
 issue-slayer × N      Implement in parallel worktrees → open PRs
+      ↓
+verify-sprint         Merge PR branches locally → visual check → squash merge to main
 ```
 
 Run `issue-raid-commander` before spawning a slayer team to avoid merge conflicts.
@@ -46,7 +48,8 @@ For single-issue work, skip it and go straight to `issue-slayer`.
 
 **Full pipeline shortcut**: `dispatching-guild-expedition` runs the entire
 workflow above in one command — Rangers × 4, user approval gate, Commander,
-then Slayers × N in parallel.
+then Slayers × N in parallel. Follow up with `verify-sprint` to verify and
+merge the opened PRs.
 
 ## Execution Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,10 @@ Issues use three label categories:
 
 This project supports autonomous AI agent development using the `issue-slayer` skill.
 
+After a sprint, use the `verify-sprint` skill to merge all PR branches into a local
+ephemeral branch, run a combined visual check, and squash-merge each PR into
+`main`. The verify branch is never pushed to remote.
+
 For detailed instructions on Agent execution patterns, eligibility, and rules, see **[AGENTS.md](AGENTS.md)**.
 
 ## Project Board


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/verify-sprint/SKILL.md` — a new skill that creates a local ephemeral verify branch, merges all sprint PR branches, runs a combined visual check via `cargo run --release`, and squash-merges each PR into `main`
- Updates `AGENTS.md` Recommended Workflow diagram to include `verify-sprint` as the final step after `issue-slayer × N`
- Updates `CONTRIBUTING.md` AI Agent Workflow section with a brief description of `verify-sprint`
- Adds a handoff note to `dispatching-guild-expedition/SKILL.md` suggesting `verify-sprint` after the sprint completes

## Design decisions

- Detailed procedure lives in the dedicated `verify-sprint` skill rather than inline in `CONTRIBUTING.md` or `AGENTS.md` — keeps those docs concise and lets the skill be loaded on demand
- The verify branch is strictly local and ephemeral (never pushed), keeping remote history clean

Closes #161