### PR TITLE
fix: guard mips[0] access against empty mip chain

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -188,8 +188,13 @@ impl TextureManager {
             self.loading_tasks.remove(&idx);
             match result {
                 Ok(mips) => {
-                    let width = mips[0].width();
-                    let height = mips[0].height();
+                    let Some(base) = mips.first() else {
+                        error!("Image {} returned empty mip chain", idx);
+                        self.errors.insert(idx, "empty mip chain".to_string());
+                        continue;
+                    };
+                    let width = base.width();
+                    let height = base.height();
 
                     let texture_size = wgpu::Extent3d {
                         width,


### PR DESCRIPTION
## Summary

Guard the `mips[0]` index access in `TextureManager::update` against an empty mip vector.

- Replace `mips[0].width()` / `mips[0].height()` with `mips.first()` using a `let-else` guard
- An empty mip chain is now treated as a load error (logged + stored in `self.errors`) rather than a runtime panic

## Changes

- `src/image_loader.rs`: replace bare `mips[0]` index with `mips.first()` guard

Closes #140