### PR TITLE
refactor: deduplicate next/prev/jump_to navigation logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -561,32 +561,14 @@ impl ApplicationState {
     fn next_image(&mut self) {
         let old_index = self.texture_manager.current_index;
         if self.texture_manager.next(self.config.viewer.pause_at_last) {
-            if self.config.viewer.playback_mode == config::PlaybackMode::Sequence {
-                self.current_texture_index = Some(self.texture_manager.current_index);
-                self.transition = None;
-                self.bind_group = None;
-            } else {
-                self.start_transition(old_index, self.texture_manager.current_index);
-            }
-            self.slideshow.reset();
-            self.sequence_timer.reset();
-            self.update_window_title();
+            self.finish_navigation(old_index);
         }
     }
 
     fn prev_image(&mut self) {
         let old_index = self.texture_manager.current_index;
         if self.texture_manager.previous() {
-            if self.config.viewer.playback_mode == config::PlaybackMode::Sequence {
-                self.current_texture_index = Some(self.texture_manager.current_index);
-                self.transition = None;
-                self.bind_group = None;
-            } else {
-                self.start_transition(old_index, self.texture_manager.current_index);
-            }
-            self.slideshow.reset();
-            self.sequence_timer.reset();
-            self.update_window_title();
+            self.finish_navigation(old_index);
         }
     }
 
@@ -594,17 +576,21 @@ impl ApplicationState {
         let old_index = self.texture_manager.current_index;
         if index < self.texture_manager.len() && index != old_index {
             self.texture_manager.jump_to(index);
-            if self.config.viewer.playback_mode == config::PlaybackMode::Sequence {
-                self.current_texture_index = Some(self.texture_manager.current_index);
-                self.transition = None;
-                self.bind_group = None;
-            } else {
-                self.start_transition(old_index, self.texture_manager.current_index);
-            }
-            self.slideshow.reset();
-            self.sequence_timer.reset();
-            self.update_window_title();
+            self.finish_navigation(old_index);
         }
+    }
+
+    fn finish_navigation(&mut self, old_index: usize) {
+        if self.config.viewer.playback_mode == config::PlaybackMode::Sequence {
+            self.current_texture_index = Some(self.texture_manager.current_index);
+            self.transition = None;
+            self.bind_group = None;
+        } else {
+            self.start_transition(old_index, self.texture_manager.current_index);
+        }
+        self.slideshow.reset();
+        self.sequence_timer.reset();
+        self.update_window_title();
     }
 
     fn timer_step(&self, increasing: bool) -> f32 {


### PR DESCRIPTION
## Summary

Extracts the shared post-navigation block from `next_image()`, `prev_image()`, and `jump_to()` into a single `finish_navigation()` helper method.

Before this change, all three methods duplicated this 6-line block:
- playback mode check → set `current_texture_index` or start transition
- `slideshow.reset()`
- `sequence_timer.reset()`
- `update_window_title()`

## Changes

- `src/app.rs`: Added `finish_navigation(old_index: usize)` helper; updated the three callers to use it

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo build` compiles cleanly
- [x] Manual: arrow key navigation, mouse click, Home/End, gallery jump all behave identically to before

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)