### PR TITLE
fix: surface clipboard initialization error with log and OSD message

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1268,12 +1268,18 @@ impl ApplicationHandler for ApplicationState {
                 } => {
                     if self.modifiers.control_key() {
                         if let Some(path) = self.texture_manager.current_path() {
-                            if let Ok(mut clipboard) = arboard::Clipboard::new() {
-                                if let Err(e) = clipboard.set_text(path.as_str()) {
-                                    error!("Failed to copy to clipboard: {}", e);
-                                } else {
-                                    info!("Copied path to clipboard: {}", path);
-                                    self.show_osd("Copied to Clipboard".to_string());
+                            match arboard::Clipboard::new() {
+                                Ok(mut clipboard) => {
+                                    if let Err(e) = clipboard.set_text(path.as_str()) {
+                                        error!("Failed to copy to clipboard: {}", e);
+                                    } else {
+                                        info!("Copied path to clipboard: {}", path);
+                                        self.show_osd("Copied to Clipboard".to_string());
+                                    }
+                                }
+                                Err(e) => {
+                                    error!("Failed to initialize clipboard: {}", e);
+                                    self.show_osd("Clipboard Unavailable".to_string());
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Replace the silent `if let Ok(...)` on `arboard::Clipboard::new()` with a `match` expression that:
- Logs the error with `error!()` when clipboard initialization fails
- Shows "Clipboard Unavailable" OSD message to the user on failure

## Changes

- `src/app.rs`: Convert `if let Ok` pattern to `match` for `Clipboard::new()` to handle the error case

Closes #148