### PR TITLE
feat: parse FPS from EXR metadata in sequence mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.8"
 
 # Image processing
 image = { version = "0.25", features = ["exr"] }
+exr = "1.72"
 
 # Utilities
 anyhow = "1.0"

--- a/example.sldshow
+++ b/example.sldshow
@@ -22,6 +22,10 @@ scan_subfolders = true  # Recursively scan directories
 shuffle = true          # Random order
 pause_at_last = false   # Stop at last image instead of looping
 cache_extent = 5        # Number of images to preload (before/after current)
+
+playback_mode = "Slideshow"  # "Slideshow" = timed advances, "Sequence" = frame-by-frame
+sequence_fps = 24.0          # Framerate for sequence playback
+                             # Auto-detected from EXR metadata (framesPerSecond) if available
 max_texture_size = [1920, 1080]  # Max texture resolution for GPU upload
                                  # Lower = faster uploads, less memory
                                  # [0, 0] = use window size (may stutter at 4K+)

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,18 @@ impl ApplicationState {
         let thumbnail_manager = ThumbnailManager::new(200);
 
         let slideshow = SlideshowTimer::new(config.viewer.timer);
-        let sequence_timer = SequenceTimer::new(config.viewer.sequence_fps);
+        let mut sequence_timer = SequenceTimer::new(config.viewer.sequence_fps);
+
+        // Auto-detect EXR framerate for sequence playback
+        if config.viewer.playback_mode == config::PlaybackMode::Sequence {
+            if let Some(detected_fps) = texture_manager.detect_sequence_fps() {
+                info!(
+                    "Detected EXR framerate: {:.2} fps (overriding config value {})",
+                    detected_fps, config.viewer.sequence_fps
+                );
+                sequence_timer.set_fps(detected_fps);
+            }
+        }
 
         // Initialize egui overlay
         let mut egui_overlay = EguiOverlay::new(

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -167,6 +167,19 @@ impl TextureManager {
         while self.rx.try_recv().is_ok() {}
     }
 
+    /// Detect framerate from EXR metadata if available.
+    /// Returns the FPS from the first EXR file found in the path list.
+    pub fn detect_sequence_fps(&self) -> Option<f32> {
+        for path in &self.paths {
+            if path.extension().unwrap_or("").eq_ignore_ascii_case("exr") {
+                if let Some(fps) = extract_exr_fps(path) {
+                    return Some(fps);
+                }
+            }
+        }
+        None
+    }
+
     pub fn len(&self) -> usize {
         self.paths.len()
     }
@@ -465,6 +478,40 @@ pub fn apply_exif_rotation(img: image::DynamicImage, path: &Utf8Path) -> image::
         },
         None => img,
     }
+}
+
+/// Extract framerate from EXR metadata.
+/// Returns None if the file is not readable or lacks framesPerSecond attribute.
+fn extract_exr_fps(path: &Utf8Path) -> Option<f32> {
+    use exr::prelude::*;
+
+    let reader = match read()
+        .no_deep_data()
+        .largest_resolution_level()
+        .all_channels()
+        .all_layers()
+        .all_attributes()
+        .non_parallel()
+        .from_file(path.as_std_path())
+    {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+
+    // Check standard framesPerSecond attribute
+    for layer in &reader.layer_data {
+        for (name, value) in &layer.attributes.other {
+            if name == "framesPerSecond" {
+                if let AttributeValue::F32(fps) = value {
+                    if *fps > 0.0 && fps.is_finite() {
+                        return Some(*fps);
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 fn resize_for_gpu(

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -112,7 +112,6 @@ impl SequenceTimer {
         self.accumulator = 0.0;
     }
 
-    #[allow(dead_code)]
     pub fn set_fps(&mut self, fps: f32) {
         self.fps = fps.max(1.0);
     }


### PR DESCRIPTION
Closes #111

## Overview
Implements automatic framerate detection from EXR metadata when using sequence playback mode.

## Changes
- Add `exr` crate dependency for direct metadata access
- Implement `extract_exr_fps()` to read `FramesPerSecond` attribute from EXR headers
- Add TextureManager::detect_sequence_fps() to scan path list for EXR files
- Auto-detect and apply EXR framerate on startup when playback_mode = Sequence
- Update `example.sldshow` with EXR auto-detection documentation
- Falls back to config.viewer.sequence_fps if metadata not found

## Testing
- ✅ cargo fmt --all -- --check
- ✅ cargo clippy --all-features -- -D warnings
- ✅ cargo test --all-features
- ✅ cargo build --release

Manual testing recommended with EXR sequence files.