### PR TITLE
fix: correct color help labels

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -399,8 +399,8 @@ impl EguiOverlay {
 
                             ui.add_space(4.0);
                             ui.heading("Color Adjustments");
-                            ui.label("1 / 2              Brightness -/+");
-                            ui.label("3 / 4              Contrast -/+");
+                            ui.label("1 / 2              Contrast -/+");
+                            ui.label("3 / 4              Brightness -/+");
                             ui.label("5 / 6              Gamma -/+");
                             ui.label("7 / 8              Saturation -/+");
 


### PR DESCRIPTION
Closes #185

## Overview
Corrects the help overlay labels so color adjustment shortcuts match actual key bindings.

## Changes
- Fix Color Adjustments help text for contrast and brightness shortcuts

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-features -- -D warnings
- [x] cargo test --all-features
- [x] cargo build --release
- [x] Manual testing recommended
