### PR TITLE
fix: invalidate stale gallery texture handles on thumbnail re-generation

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -232,11 +232,18 @@ impl EguiOverlay {
         self.show_settings || self.show_help_overlay || self.show_gallery || self.osc.visible
     }
 
-    fn cleanup_gallery_textures(&mut self, thumbnail_manager: &ThumbnailManager) {
+    fn cleanup_gallery_textures(&mut self, thumbnail_manager: &mut ThumbnailManager) {
+        // Remove handles for thumbnails that are no longer in the cache (evicted).
         let cached_indices: std::collections::HashSet<_> =
             thumbnail_manager.get_cached_indices().into_iter().collect();
         self.gallery_textures
             .retain(|k, _| cached_indices.contains(k));
+
+        // Invalidate handles for thumbnails that were re-generated since the last
+        // frame. The next render will recreate them from the fresh pixel data.
+        for index in thumbnail_manager.drain_newly_cached() {
+            self.gallery_textures.remove(&index);
+        }
     }
 
     /// Update OSC activity (call on mouse movement)

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -34,6 +34,11 @@ pub struct ThumbnailManager {
     pending_queue: VecDeque<(usize, Utf8PathBuf)>,
     tx: Sender<(usize, anyhow::Result<RgbaImage>)>,
     rx: Receiver<(usize, anyhow::Result<RgbaImage>)>,
+
+    /// Indices of thumbnails that were newly inserted into the cache since the
+    /// last call to `drain_newly_cached()`. Used by the overlay to invalidate
+    /// stale egui texture handles after a thumbnail is re-generated.
+    newly_cached: Vec<usize>,
 }
 
 #[allow(dead_code)]
@@ -49,6 +54,7 @@ impl ThumbnailManager {
             pending_queue: VecDeque::new(),
             tx,
             rx,
+            newly_cached: Vec::new(),
         }
     }
 
@@ -99,6 +105,7 @@ impl ThumbnailManager {
                         debug!("Evicted thumbnail {} from cache", evict_index);
                     }
                     debug!("Cached thumbnail {}", index);
+                    self.newly_cached.push(index);
                 }
                 Err(e) => {
                     warn!("Failed to generate thumbnail {}: {}", index, e);
@@ -132,6 +139,7 @@ impl ThumbnailManager {
         self.cache.clear();
         self.loading_tasks.clear();
         self.pending_queue.clear();
+        self.newly_cached.clear();
         // Recreate channel so old threads' tx handles are orphaned;
         // their sends will silently fail without leaking loading_tasks.
         let (tx, rx) = channel();
@@ -143,6 +151,15 @@ impl ThumbnailManager {
     /// Used to reset priorities when the requested set changes (e.g. rapid scrolling).
     pub fn clear_pending(&mut self) {
         self.pending_queue.clear();
+    }
+
+    /// Return and clear the list of indices whose thumbnails were newly inserted
+    /// into the cache since the last call to this method.
+    ///
+    /// Call this each frame to invalidate stale egui texture handles so the gallery
+    /// view displays the latest thumbnail data after a re-generation.
+    pub fn drain_newly_cached(&mut self) -> Vec<usize> {
+        std::mem::take(&mut self.newly_cached)
     }
 
     /// Returns the number of cached thumbnails.


### PR DESCRIPTION
Closes #184

## Overview

Gallery thumbnail `TextureHandle`s were never refreshed after the `ThumbnailManager` evicted and re-generated a thumbnail, because `entry().or_insert_with()` only runs its closure when the key is absent.

## Changes

- `src/thumbnail.rs` — Added `newly_cached: Vec<usize>` field to `ThumbnailManager`; populated in `update()` each time a fresh thumbnail is inserted into the LRU cache; exposed via new `drain_newly_cached()` method; `clear()` also resets the buffer.
- `src/overlay.rs` — `cleanup_gallery_textures()` now takes `&mut ThumbnailManager` and calls `drain_newly_cached()` to remove stale egui `TextureHandle` entries. On the next render frame, `or_insert_with` recreates the handle from the fresh pixel data.

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7/7)
- [x] `cargo build` passed
- [x] Manual testing: open gallery, trigger LRU eviction by scrolling through many images, then scroll back — thumbnails should display up-to-date data
