### PR TITLE
perf: use rayon thread pool for image loading instead of spawning OS threads

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -323,7 +323,7 @@ impl TextureManager {
 
                     self.loading_tasks.insert(idx, self.epoch);
 
-                    std::thread::spawn(move || {
+                    rayon::spawn(move || {
                         let res = std::panic::catch_unwind(|| load_image_rgba(&path, max_size))
                             .unwrap_or_else(|payload| {
                                 let msg = if let Some(s) = payload.downcast_ref::<String>() {


### PR DESCRIPTION
Closes #175

## Overview
Replace `std::thread::spawn` with `rayon::spawn` in `TextureManager::update()` so image loading tasks reuse rayon's pre-allocated global thread pool instead of creating and destroying an OS thread for every load request.

## Changes
- `src/image_loader.rs`: one-line change — `std::thread::spawn` → `rayon::spawn` (rayon was already a dependency)

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7/7)
- [x] `cargo build --release` passed
- [x] Manual testing recommended: `cargo run --release -- test.sldshow` and verify rapid navigation loads images without regression
