### PR TITLE
fix: skip transition when duration is zero to prevent div-by-zero

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -643,6 +643,15 @@ impl ApplicationState {
         }
     }
     fn start_transition(&mut self, from_index: usize, to_index: usize) {
+        // If transition time is 0, do an instant cut to avoid division by zero
+        // in the render loop (elapsed / duration would produce NaN).
+        if self.config.transition.time == 0.0 {
+            self.current_texture_index = Some(to_index);
+            self.transition = None;
+            self.renderer.invalidate_bind_group();
+            return;
+        }
+
         let mode = if self.config.transition.random {
             TransitionPipeline::random_mode()
         } else {


### PR DESCRIPTION
Closes #179

## Overview
When `transition.time = 0.0`, the render loop divided elapsed time by a zero duration, producing NaN values that propagated to the GPU uniform buffer causing undefined shader behavior (black frames or visual glitches).

## Changes
- `src/app.rs`: In `start_transition()`, added an early-return guard for `transition.time == 0.0` that performs an instant cut (sets `current_texture_index` directly) instead of creating an `ActiveTransition` with zero duration.

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7/7 tests)
- [x] `cargo build --release` passed
- [x] Manual testing: set `transition.time = 0.0` in config and verify images advance without black frames or glitches
