### PR TITLE
fix: handle WindowEvent::DroppedFile for drag-and-drop on Linux/macOS

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1156,6 +1156,12 @@ impl ApplicationHandler for ApplicationState {
                             Err(e) => error!("Render error: {:?}", e),
                         }
                     }
+                    // Handle drag-and-drop on non-Windows platforms via winit's
+                    // DroppedFile event. Windows uses WM_DROPFILES (see drag_drop.rs).
+                    #[cfg(not(windows))]
+                    WindowEvent::DroppedFile(path) => {
+                        self.drag_drop.queue_dropped_file(path);
+                    }
                     _ => {}
                 }
             }

--- a/src/drag_drop.rs
+++ b/src/drag_drop.rs
@@ -1,24 +1,33 @@
-//! Drag & drop handler using Windows WM_DROPFILES API.
+//! Drag & drop handler.
 //!
-//! winit 0.29 registers OLE drag-and-drop by default, but on some Windows
-//! configurations the events never fire. This module replaces that with the
-//! simpler, more reliable `DragAcceptFiles` / `WM_DROPFILES` mechanism.
+//! On Windows, uses the `WM_DROPFILES` API directly (bypasses winit's OLE
+//! drag-and-drop which can be unreliable on some configurations).
+//! On other platforms, `WindowEvent::DroppedFile` events are forwarded through
+//! the same channel via [`DragDropHandler::queue_dropped_file`].
 
 use camino::Utf8PathBuf;
 use std::sync::mpsc;
 
 /// Receiver half lives in `ApplicationState`, sender is captured by the
-/// event-loop message hook.
+/// event-loop message hook (Windows) or used directly via
+/// [`DragDropHandler::queue_dropped_file`] (non-Windows).
 pub struct DragDropHandler {
     rx: mpsc::Receiver<Vec<Utf8PathBuf>>,
+    /// Retained so non-Windows platforms can enqueue files from window events.
+    #[cfg(not(windows))]
+    tx: mpsc::Sender<Vec<Utf8PathBuf>>,
 }
 
 impl DragDropHandler {
-    /// Create a handler pair.  Returns `(handler, sender)` — the sender must
-    /// be moved into the message hook via [`install_msg_hook`].
+    /// Create a handler pair.  On Windows the returned sender must be moved
+    /// into the message hook via [`build_msg_hook`].
     pub fn new() -> (Self, mpsc::Sender<Vec<Utf8PathBuf>>) {
         let (tx, rx) = mpsc::channel();
-        (Self { rx }, tx)
+        #[cfg(windows)]
+        let handler = Self { rx };
+        #[cfg(not(windows))]
+        let handler = Self { rx, tx: tx.clone() };
+        (handler, tx)
     }
 
     /// Drain all batches received since the last call. Returns `None` when
@@ -29,6 +38,20 @@ impl DragDropHandler {
             all.extend(batch);
         }
         if all.is_empty() { None } else { Some(all) }
+    }
+
+    /// Enqueue a single dropped file path (non-Windows only).
+    ///
+    /// Call this from `WindowEvent::DroppedFile` on Linux/macOS so that the
+    /// existing drain logic in [`take_pending`] picks it up on the next frame.
+    #[cfg(not(windows))]
+    pub fn queue_dropped_file(&self, path: std::path::PathBuf) {
+        match Utf8PathBuf::try_from(path) {
+            Ok(p) => {
+                let _ = self.tx.send(vec![p]);
+            }
+            Err(e) => log::warn!("Dropped path is not valid UTF-8: {}", e),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #174

## Overview

Drag and drop was entirely broken on Linux/macOS because `WindowEvent::DroppedFile` was never handled. Windows uses a custom `WM_DROPFILES` hook (in `src/drag_drop.rs`) for reliability; other platforms rely on winit's standard event which was simply ignored.

## Changes

- **`src/drag_drop.rs`**: Added `queue_dropped_file(path)` method to `DragDropHandler` (non-Windows only). Stores a sender clone in the struct and forwards a single-path batch through the existing mpsc channel, so `take_pending()` drains it unchanged.
- **`src/app.rs`**: Added `WindowEvent::DroppedFile(path)` arm in `window_event()`, guarded with `#[cfg(not(windows))]`. Calls `self.drag_drop.queue_dropped_file(path)` — the existing update-loop drain+scan logic handles the rest.

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7/7)
- [x] `cargo build --release` passed
- [ ] Manual testing on Linux/macOS recommended (drag image files onto window)
