### PR TITLE
feat: add Shift+Backspace shortcut to reset all color adjustments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -380,6 +380,7 @@ impl ApplicationState {
             InputAction::ResetTimer => self.reset_timer(),
             InputAction::Screenshot => self.screenshot_requested = true,
             InputAction::ColorAdjust { key } => self.handle_color_key(key),
+            InputAction::ResetColorAdjustments => self.reset_color_adjustments(),
             InputAction::ToggleInfoOverlay => {
                 let visible = self.egui_overlay.toggle_info_overlay();
                 self.info_temp_expiry = None;
@@ -556,6 +557,14 @@ impl ApplicationState {
             format!("{}: {:.2}", name, *value)
         };
         self.show_osd(msg);
+    }
+
+    fn reset_color_adjustments(&mut self) {
+        self.color_brightness = 0.0;
+        self.color_contrast = 1.0;
+        self.color_gamma = 1.0;
+        self.color_saturation = 1.0;
+        self.show_osd("Color Reset".to_string());
     }
 
     fn build_info_string(&self) -> String {

--- a/src/input.rs
+++ b/src/input.rs
@@ -25,6 +25,7 @@ pub enum InputAction {
     ResetTimer,
     Screenshot,
     ColorAdjust { key: KeyCode },
+    ResetColorAdjustments,
     ToggleInfoOverlay,
     ShowInfoTemporary,
     ToggleFilenameDisplay,
@@ -268,7 +269,13 @@ impl InputHandler {
                 };
                 Some(InputAction::AdjustTimer(delta))
             }
-            PhysicalKey::Code(KeyCode::Backspace) => Some(InputAction::ResetTimer),
+            PhysicalKey::Code(KeyCode::Backspace) => {
+                if modifiers.shift_key() {
+                    Some(InputAction::ResetColorAdjustments)
+                } else {
+                    Some(InputAction::ResetTimer)
+                }
+            }
             PhysicalKey::Code(KeyCode::KeyS) => Some(InputAction::Screenshot),
             PhysicalKey::Code(
                 key @ (KeyCode::Digit1


### PR DESCRIPTION
Closes #126

## Overview
Adds a `Shift+Backspace` keyboard shortcut that resets all four color adjustment values (brightness, contrast, gamma, saturation) back to their defaults in one keystroke.

## Changes
- `src/input.rs`: Added `ResetColorAdjustments` variant to `InputAction` enum; updated `Backspace` key binding to emit `ResetColorAdjustments` when Shift is held (plain `Backspace` retains its existing `ResetTimer` behavior)
- `src/app.rs`: Added `reset_color_adjustments()` method that restores hardcoded defaults (`brightness=0.0`, `contrast=1.0`, `gamma=1.0`, `saturation=1.0`) and shows an OSD "Color Reset" message; added dispatch arm for `ResetColorAdjustments`

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed (no warnings)
- [x] `cargo test --all-features` passed (7/7 tests)
- [x] `cargo build --release` succeeded
- [x] Manual: press keys `1`–`8` to adjust colors, then `Shift+Backspace` to verify all values reset and OSD shows "Color Reset"
