### PR TITLE
perf: skip redraws when application is visually idle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1030,6 +1030,29 @@ impl ApplicationState {
     fn show_osd(&mut self, text: String) {
         self.osd_message = Some((text, Instant::now() + Duration::from_millis(1500)));
     }
+
+    /// Returns `true` when something on screen is actively changing and a
+    /// redraw must be requested every frame.  When this returns `false` the
+    /// application is visually idle and can stop polling the GPU.
+    fn is_animating(&self) -> bool {
+        // Active image transition
+        self.transition.is_some()
+            // Slideshow auto-advance is running
+            || !self.slideshow.paused
+            // Sequence playback is running
+            || (self.config.viewer.playback_mode == config::PlaybackMode::Sequence
+                && !self.sequence_timer.paused)
+            // OSD message or temporary overlay still visible
+            || self.osd_message.is_some()
+            || self.filename_bar_temp_expiry.is_some()
+            || self.info_temp_expiry.is_some()
+            // Egui overlays or OSC are open/visible
+            || self.egui_overlay.is_active()
+            // Texture loads in flight — update() must run to receive results
+            || self.texture_manager.is_loading()
+            // Cursor visible — update() must run to auto-hide it
+            || self.input_handler.cursor_visible
+    }
 }
 
 impl ApplicationHandler for ApplicationState {
@@ -1207,9 +1230,14 @@ impl ApplicationHandler for ApplicationState {
                 _ => {}
             }
         }
+
+        // Ensure the result of any window event is reflected on screen.
+        self.window.request_redraw();
     }
 
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
-        self.window.request_redraw();
+        if self.is_animating() {
+            self.window.request_redraw();
+        }
     }
 }

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -200,6 +200,11 @@ impl TextureManager {
         self.errors.get(&index)
     }
 
+    /// Returns `true` while any texture loads are still in progress.
+    pub fn is_loading(&self) -> bool {
+        !self.loading_tasks.is_empty()
+    }
+
     pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
         if self.paths.is_empty() {
             return;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -226,6 +226,12 @@ impl EguiOverlay {
         self.show_gallery = !self.show_gallery;
     }
 
+    /// Returns `true` when any overlay or the OSC is currently visible,
+    /// meaning redraws are needed to animate or respond to input.
+    pub fn is_active(&self) -> bool {
+        self.show_settings || self.show_help_overlay || self.show_gallery || self.osc.visible
+    }
+
     fn cleanup_gallery_textures(&mut self, thumbnail_manager: &ThumbnailManager) {
         let cached_indices: std::collections::HashSet<_> =
             thumbnail_manager.get_cached_indices().into_iter().collect();


### PR DESCRIPTION
Closes #150

## Overview
Replaces the unconditional `window.request_redraw()` in `about_to_wait` with a conditional check, reducing CPU/GPU usage to near-zero when the application is visually idle (paused, no transition, no overlays).

## Changes
- `src/app.rs`: Add `is_animating()` helper method that returns `true` when any of the following require continuous redraws: active transition, running slideshow/sequence timer, visible OSD/temp overlays, open egui overlays (settings/help/gallery/OSC), in-flight texture loads, or visible cursor (pending auto-hide). Update `about_to_wait` to call `request_redraw()` only when `is_animating()` is true. Add `request_redraw()` call at the end of `window_event` to ensure user input changes are always reflected.
- `src/image_loader.rs`: Add `is_loading() -> bool` helper to `TextureManager` that reports whether any background texture loads are in progress.
- `src/overlay.rs`: Add `is_active() -> bool` helper to `EguiOverlay` that reports whether any overlay or the OSC is currently visible.

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed (0 warnings)
- [x] `cargo test --all-features` passed (7/7 tests)
- [x] `cargo build --release` succeeded
- [x] Manual testing recommended: verify slideshow advances, transitions animate, OSD messages appear, keyboard/mouse input responds immediately, OSC hides after inactivity
