### PR TITLE
fix: defer surface reconfigure to render frame to eliminate resize stutter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,10 @@ pub struct ApplicationState {
     // Zoom/pan state
     zoom_scale: f32,
     zoom_pan: [f32; 2],
+
+    // Deferred resize — set on WindowEvent::Resized, applied at the start of render()
+    // to avoid reconfiguring the surface on every rapid resize event.
+    pending_resize: Option<winit::dpi::PhysicalSize<u32>>,
 }
 
 struct ActiveTransition {
@@ -195,6 +199,7 @@ impl ApplicationState {
             cached_info_string: None,
             zoom_scale: 1.0,
             zoom_pan: [0.0, 0.0],
+            pending_resize: None,
         };
 
         state.update_window_title();
@@ -974,6 +979,11 @@ impl ApplicationState {
     }
 
     fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+        // Apply any deferred resize before touching the surface.
+        if let Some(new_size) = self.pending_resize.take() {
+            self.resize(new_size);
+        }
+
         let output = self.renderer.surface.get_current_texture()?;
         let view = output
             .texture
@@ -1209,7 +1219,14 @@ impl ApplicationHandler for ApplicationState {
                 match event {
                     WindowEvent::CloseRequested => event_loop.exit(),
                     WindowEvent::Resized(physical_size) => {
-                        self.resize(physical_size);
+                        // Defer surface reconfiguration to the next render() call.
+                        // During a live window drag the OS fires many Resized events
+                        // per frame; reconfiguring the surface on each one causes
+                        // visible stuttering. Storing only the latest size here
+                        // collapses all intermediate events into a single resize that
+                        // is applied once, right before the next frame is drawn.
+                        self.pending_resize = Some(physical_size);
+                        self.window.request_redraw();
                     }
                     WindowEvent::ScaleFactorChanged {
                         scale_factor,

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,7 +28,9 @@ pub enum InputAction {
     AdjustTimer(f32),
     ResetTimer,
     Screenshot,
-    ColorAdjust { key: KeyCode },
+    ColorAdjust {
+        key: KeyCode,
+    },
     ResetColorAdjustments,
     ToggleInfoOverlay,
     ShowInfoTemporary,
@@ -44,7 +46,10 @@ pub enum InputAction {
     ToggleHelpOverlay,
     ToggleGallery,
     Exit,
-    ResizeWindow { width: u32, height: u32 },
+    ResizeWindow {
+        width: u32,
+        height: u32,
+    },
     CopyPathToClipboard,
     OpenInExplorer,
     /// Zoom in (delta > 0) or out (delta < 0). Delta is a multiplicative scroll step.


### PR DESCRIPTION
Closes #215

## Overview

Defers `surface.configure()` from `WindowEvent::Resized` to the next render frame. During a live window drag the OS fires many `Resized` events per frame; reconfiguring the wgpu surface on each one causes visible stuttering. This change collapses all intermediate resize events into a single surface reconfiguration applied once, right before the next frame is drawn.

## Changes

- Add `pending_resize: Option<PhysicalSize<u32>>` field to `ApplicationState`
- `WindowEvent::Resized` now stores the size in `pending_resize` and calls `request_redraw()` instead of calling `self.resize()` directly
- `render()` checks `pending_resize.take()` at the top and applies it before accessing the surface
- `SurfaceError::Lost` continues to call `self.resize(self.size)` directly (error-recovery path, unchanged)
- `src/input.rs` reformatted by `cargo fmt` (pre-existing style drift)

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed
- [x] `cargo build --release` passed
- [ ] Manual: resize the window rapidly by dragging its edge — stutter should be gone
