### PR TITLE
fix: change Alt+1 resize preset to 1024x768 to avoid overlap with default config

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -28,7 +28,9 @@ pub enum InputAction {
     AdjustTimer(f32),
     ResetTimer,
     Screenshot,
-    ColorAdjust { key: KeyCode },
+    ColorAdjust {
+        key: KeyCode,
+    },
     ResetColorAdjustments,
     ToggleInfoOverlay,
     ShowInfoTemporary,
@@ -44,7 +46,10 @@ pub enum InputAction {
     ToggleHelpOverlay,
     ToggleGallery,
     Exit,
-    ResizeWindow { width: u32, height: u32 },
+    ResizeWindow {
+        width: u32,
+        height: u32,
+    },
     CopyPathToClipboard,
     OpenInExplorer,
     /// Zoom in (delta > 0) or out (delta < 0). Delta is a multiplicative scroll step.
@@ -373,8 +378,8 @@ impl InputHandler {
             }
             PhysicalKey::Code(KeyCode::Digit1) if modifiers.alt_key() => {
                 Some(InputAction::ResizeWindow {
-                    width: 1280,
-                    height: 720,
+                    width: 1024,
+                    height: 768,
                 })
             }
             PhysicalKey::Code(KeyCode::Digit2) if modifiers.alt_key() => {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -411,6 +411,12 @@ impl EguiOverlay {
                             ui.label("O / Shift+O        Show filename temporarily / toggle");
 
                             ui.add_space(4.0);
+                            ui.heading("Window Resize");
+                            ui.label("Alt+0              Configured default size");
+                            ui.label("Alt+1              1024x768");
+                            ui.label("Alt+2              1920x1080 (Full HD)");
+
+                            ui.add_space(4.0);
                             ui.heading("Color Adjustments");
                             ui.label("1 / 2              Contrast -/+");
                             ui.label("3 / 4              Brightness -/+");


### PR DESCRIPTION
Closes #213

## Overview

Alt+0 restores the configured default window size (1280x720 by default), and Alt+1 was previously hardcoded to 1280x720 -- making the two shortcuts identical on a default install. This fixes the issue by changing Alt+1 to the distinct 1024x768 preset and documents all three window-resize shortcuts in the help overlay.

## Changes

- src/input.rs: Change Alt+1 preset from 1280x720 to 1024x768
- src/overlay.rs: Add Window Resize section to the keyboard shortcuts help overlay, listing Alt+0 (configured default), Alt+1 (1024x768), and Alt+2 (1920x1080)

## Testing

- [x] cargo fmt --all --check passes
- [x] cargo clippy --all-features -- -D warnings passes (no warnings)
- [x] cargo test --all-features passes (7/7 tests)
- [x] cargo build --release passes
- [x] Manual test: press ? to open help overlay and confirm Window Resize section is visible; press Alt+0/1/2 and verify each resizes to the correct distinct dimension