### PR TITLE
fix: handle SurfaceError::Outdated in render loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1241,7 +1241,9 @@ impl ApplicationHandler for ApplicationState {
                         self.update();
                         match self.render() {
                             Ok(_) => {}
-                            Err(wgpu::SurfaceError::Lost) => self.resize(self.size),
+                            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                                self.resize(self.size)
+                            }
                             Err(wgpu::SurfaceError::OutOfMemory) => {
                                 error!("GPU out of memory — exiting");
                                 event_loop.exit();


### PR DESCRIPTION
## Summary

- Treat `wgpu::SurfaceError::Outdated` the same as `SurfaceError::Lost` by triggering a surface reconfigure via `self.resize(self.size)`.
- Prevents a crash/hang when the swap chain becomes outdated (e.g., during window resizing on some platforms or driver events).

## Change

```rust
// Before:
Err(wgpu::SurfaceError::Lost) => self.resize(self.size),

// After:
Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
    self.resize(self.size)
}
```

## Test plan

- [x] Build passes: `cargo build --release`
- [x] Clippy clean: `cargo clippy --all-features -- -D warnings`
- [x] No regressions in test suite: `cargo test --all-features`
- [x] Manual: resize window rapidly and confirm no crashes

Closes #200
