### PR TITLE
fix: prevent settings panel drag from moving main window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1204,14 +1204,17 @@ impl ApplicationHandler for ApplicationState {
             return;
         }
 
-        // Sample wants_pointer_input() BEFORE handle_event so we use the previous
-        // frame's layout for hit-testing. This avoids a one-frame delay where egui
-        // hasn't yet computed widget positions for the current frame, which would
-        // cause the first mouse-press on an egui panel to slip through to InputHandler.
+        // Sample wants_pointer_input() BEFORE handle_event to use the previous
+        // frame's layout for hit-testing (avoids one-frame delay on initial press).
         let egui_wants_pointer = self.egui_overlay.wants_pointer_input();
 
         // Forward event to egui first
         let egui_consumed = self.egui_overlay.handle_event(&self.window, &event);
+
+        // Also check is_using_pointer() AFTER handle_event: catches interactions
+        // (resize, drag) that started this frame where the press landed on a widget
+        // edge outside the previous frame's hover area (e.g. resize handle corner).
+        let egui_using_pointer = self.egui_overlay.is_using_pointer();
 
         // For pointer/mouse events, suppress InputHandler when egui owns the pointer.
         // Keyboard events are always forwarded regardless.
@@ -1221,7 +1224,7 @@ impl ApplicationHandler for ApplicationState {
                 WindowEvent::MouseInput { .. }
                     | WindowEvent::CursorMoved { .. }
                     | WindowEvent::MouseWheel { .. }
-            ) && egui_wants_pointer);
+            ) && (egui_wants_pointer || egui_using_pointer));
 
         // Try input handler only if egui didn't consume the event
         let modifiers = self.modifiers;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -257,10 +257,17 @@ impl EguiOverlay {
     }
 
     /// Returns true if egui currently wants to capture pointer/mouse input.
-    /// Use this to suppress pointer events from reaching the application
-    /// when an egui panel (e.g. Settings) is being interacted with.
+    /// Based on the previous frame's layout — call BEFORE handle_event() to
+    /// avoid a one-frame delay on the initial press.
     pub fn wants_pointer_input(&self) -> bool {
         self.state.egui_ctx().wants_pointer_input()
+    }
+
+    /// Returns true if egui is actively using the pointer this frame
+    /// (drag, resize, or other interaction in progress).
+    /// Call AFTER handle_event() to catch interactions that started this frame.
+    pub fn is_using_pointer(&self) -> bool {
+        self.state.egui_ctx().is_using_pointer()
     }
 
     /// Forward winit events to egui


### PR DESCRIPTION
## Summary

- Add `wants_pointer_input()` method to `EguiOverlay` that delegates to `egui_ctx().wants_pointer_input()`.
- In `app.rs`, introduce `egui_blocks_input` which is true when `egui_consumed` is true OR when egui wants pointer input AND the event is a mouse event (`MouseInput`, `CursorMoved`, `MouseWheel`).
- Keyboard events are unaffected — they always reach the `InputHandler`.

## Problem

When the Settings panel was open and the user dragged its title bar, egui would handle the drag internally but `handle_event()` would return `consumed = false` for the mouse press. This caused the `InputHandler` to also capture the drag, triggering window movement alongside the panel drag.

## Test plan

- [ ] Open Settings panel (`Alt+S` or similar)
- [ ] Drag the Settings panel title bar — window should NOT move
- [x] Click/drag outside the Settings panel — window should move normally
- [x] Mouse wheel outside Settings panel — image navigation still works
- [x] Keyboard shortcuts still work while Settings panel is open
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

Closes #214
