### PR TITLE
feat: mpv-style image-relative resize for Alt+0/1/2

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -219,11 +219,15 @@ impl ApplicationState {
         event: &WindowEvent,
         modifiers: &winit::keyboard::ModifiersState,
     ) -> (bool, bool) {
+        let current_image_size = self
+            .texture_manager
+            .get_current_texture()
+            .map(|t| (t.width, t.height));
         let ctx = InputContext {
             fullscreen: self.window.fullscreen().is_some(),
             image_count: self.texture_manager.len(),
             help_visible: self.egui_overlay.help_overlay_visible(),
-            window_default_size: (self.config.window.width, self.config.window.height),
+            current_image_size,
         };
         let (consumed, action) =
             self.input_handler

--- a/src/input.rs
+++ b/src/input.rs
@@ -70,7 +70,8 @@ pub struct InputContext {
     pub fullscreen: bool,
     pub image_count: usize,
     pub help_visible: bool,
-    pub window_default_size: (u32, u32),
+    /// Size of the currently displayed image in pixels, if any.
+    pub current_image_size: Option<(u32, u32)>,
 }
 
 /// Input state tracker.
@@ -138,7 +139,7 @@ impl InputHandler {
                 modifiers,
                 ctx.image_count,
                 ctx.help_visible,
-                ctx.window_default_size,
+                ctx.current_image_size,
             ),
             _ => (false, None),
         }
@@ -304,126 +305,124 @@ impl InputHandler {
         modifiers: &ModifiersState,
         image_count: usize,
         help_visible: bool,
-        window_default_size: (u32, u32),
+        current_image_size: Option<(u32, u32)>,
     ) -> (bool, Option<InputAction>) {
         self.last_cursor_move = Instant::now();
 
-        let action = match physical_key {
-            PhysicalKey::Code(KeyCode::Escape) => {
-                if help_visible {
+        let action =
+            match physical_key {
+                PhysicalKey::Code(KeyCode::Escape) => {
+                    if help_visible {
+                        Some(InputAction::ToggleHelpOverlay)
+                    } else {
+                        Some(InputAction::Exit)
+                    }
+                }
+                PhysicalKey::Code(KeyCode::KeyQ) => Some(InputAction::Exit),
+                PhysicalKey::Code(KeyCode::ArrowRight) | PhysicalKey::Code(KeyCode::Space) => {
+                    let steps = if modifiers.shift_key() { 10 } else { 1 };
+                    Some(InputAction::NextImage { steps })
+                }
+                PhysicalKey::Code(KeyCode::ArrowLeft) => {
+                    let steps = if modifiers.shift_key() { 10 } else { 1 };
+                    Some(InputAction::PrevImage { steps })
+                }
+                PhysicalKey::Code(KeyCode::Home) => Some(InputAction::JumpTo(0)),
+                PhysicalKey::Code(KeyCode::End) => {
+                    Some(InputAction::JumpTo(image_count.saturating_sub(1)))
+                }
+                PhysicalKey::Code(KeyCode::KeyP) => Some(InputAction::TogglePause),
+                PhysicalKey::Code(KeyCode::KeyF) => Some(InputAction::ToggleFullscreen),
+                PhysicalKey::Code(KeyCode::KeyD) => Some(InputAction::ToggleDecorations),
+                PhysicalKey::Code(KeyCode::KeyT) => Some(InputAction::ToggleAlwaysOnTop),
+                PhysicalKey::Code(KeyCode::BracketLeft) => {
+                    let delta = if modifiers.shift_key() {
+                        -60.0
+                    } else {
+                        // Timer step calculation deferred to ApplicationState
+                        -1.0 // Placeholder, will be recalculated
+                    };
+                    Some(InputAction::AdjustTimer(delta))
+                }
+                PhysicalKey::Code(KeyCode::BracketRight) => {
+                    let delta = if modifiers.shift_key() {
+                        60.0
+                    } else {
+                        1.0 // Placeholder
+                    };
+                    Some(InputAction::AdjustTimer(delta))
+                }
+                PhysicalKey::Code(KeyCode::Backspace) => {
+                    if modifiers.shift_key() {
+                        Some(InputAction::ResetColorAdjustments)
+                    } else {
+                        Some(InputAction::ResetTimer)
+                    }
+                }
+                PhysicalKey::Code(KeyCode::KeyS) => Some(InputAction::Screenshot),
+                PhysicalKey::Code(
+                    key @ (KeyCode::Digit1
+                    | KeyCode::Digit2
+                    | KeyCode::Digit3
+                    | KeyCode::Digit4
+                    | KeyCode::Digit5
+                    | KeyCode::Digit6
+                    | KeyCode::Digit7
+                    | KeyCode::Digit8),
+                ) if !modifiers.alt_key() && !modifiers.shift_key() && !modifiers.control_key() => {
+                    Some(InputAction::ColorAdjust { key: *key })
+                }
+                PhysicalKey::Code(KeyCode::Digit0) if modifiers.alt_key() => current_image_size
+                    .map(|(w, h)| InputAction::ResizeWindow {
+                        width: (w / 2).max(1),
+                        height: (h / 2).max(1),
+                    }),
+                PhysicalKey::Code(KeyCode::Digit1) if modifiers.alt_key() => current_image_size
+                    .map(|(w, h)| InputAction::ResizeWindow {
+                        width: w,
+                        height: h,
+                    }),
+                PhysicalKey::Code(KeyCode::Digit2) if modifiers.alt_key() => current_image_size
+                    .map(|(w, h)| InputAction::ResizeWindow {
+                        width: w * 2,
+                        height: h * 2,
+                    }),
+                PhysicalKey::Code(KeyCode::KeyI) => {
+                    if modifiers.shift_key() {
+                        Some(InputAction::ToggleInfoOverlay)
+                    } else {
+                        Some(InputAction::ShowInfoTemporary)
+                    }
+                }
+                PhysicalKey::Code(KeyCode::KeyO) => {
+                    if modifiers.shift_key() {
+                        Some(InputAction::ToggleFilenameDisplay)
+                    } else {
+                        Some(InputAction::ShowFilenameTemporary)
+                    }
+                }
+                PhysicalKey::Code(KeyCode::KeyL) => Some(InputAction::ToggleLoop),
+                PhysicalKey::Code(KeyCode::KeyA) => Some(InputAction::ToggleFitMode),
+                PhysicalKey::Code(KeyCode::KeyC)
+                    if modifiers.control_key() && modifiers.shift_key() =>
+                {
+                    Some(InputAction::CopyImageToClipboard)
+                }
+                PhysicalKey::Code(KeyCode::KeyC)
+                    if modifiers.control_key() && !modifiers.shift_key() =>
+                {
+                    Some(InputAction::CopyPathToClipboard)
+                }
+                PhysicalKey::Code(KeyCode::KeyE) if modifiers.alt_key() => {
+                    Some(InputAction::OpenInExplorer)
+                }
+                PhysicalKey::Code(KeyCode::Slash) if modifiers.shift_key() => {
                     Some(InputAction::ToggleHelpOverlay)
-                } else {
-                    Some(InputAction::Exit)
                 }
-            }
-            PhysicalKey::Code(KeyCode::KeyQ) => Some(InputAction::Exit),
-            PhysicalKey::Code(KeyCode::ArrowRight) | PhysicalKey::Code(KeyCode::Space) => {
-                let steps = if modifiers.shift_key() { 10 } else { 1 };
-                Some(InputAction::NextImage { steps })
-            }
-            PhysicalKey::Code(KeyCode::ArrowLeft) => {
-                let steps = if modifiers.shift_key() { 10 } else { 1 };
-                Some(InputAction::PrevImage { steps })
-            }
-            PhysicalKey::Code(KeyCode::Home) => Some(InputAction::JumpTo(0)),
-            PhysicalKey::Code(KeyCode::End) => {
-                Some(InputAction::JumpTo(image_count.saturating_sub(1)))
-            }
-            PhysicalKey::Code(KeyCode::KeyP) => Some(InputAction::TogglePause),
-            PhysicalKey::Code(KeyCode::KeyF) => Some(InputAction::ToggleFullscreen),
-            PhysicalKey::Code(KeyCode::KeyD) => Some(InputAction::ToggleDecorations),
-            PhysicalKey::Code(KeyCode::KeyT) => Some(InputAction::ToggleAlwaysOnTop),
-            PhysicalKey::Code(KeyCode::BracketLeft) => {
-                let delta = if modifiers.shift_key() {
-                    -60.0
-                } else {
-                    // Timer step calculation deferred to ApplicationState
-                    -1.0 // Placeholder, will be recalculated
-                };
-                Some(InputAction::AdjustTimer(delta))
-            }
-            PhysicalKey::Code(KeyCode::BracketRight) => {
-                let delta = if modifiers.shift_key() {
-                    60.0
-                } else {
-                    1.0 // Placeholder
-                };
-                Some(InputAction::AdjustTimer(delta))
-            }
-            PhysicalKey::Code(KeyCode::Backspace) => {
-                if modifiers.shift_key() {
-                    Some(InputAction::ResetColorAdjustments)
-                } else {
-                    Some(InputAction::ResetTimer)
-                }
-            }
-            PhysicalKey::Code(KeyCode::KeyS) => Some(InputAction::Screenshot),
-            PhysicalKey::Code(
-                key @ (KeyCode::Digit1
-                | KeyCode::Digit2
-                | KeyCode::Digit3
-                | KeyCode::Digit4
-                | KeyCode::Digit5
-                | KeyCode::Digit6
-                | KeyCode::Digit7
-                | KeyCode::Digit8),
-            ) if !modifiers.alt_key() && !modifiers.shift_key() && !modifiers.control_key() => {
-                Some(InputAction::ColorAdjust { key: *key })
-            }
-            PhysicalKey::Code(KeyCode::Digit0) if modifiers.alt_key() => {
-                Some(InputAction::ResizeWindow {
-                    width: window_default_size.0,
-                    height: window_default_size.1,
-                })
-            }
-            PhysicalKey::Code(KeyCode::Digit1) if modifiers.alt_key() => {
-                Some(InputAction::ResizeWindow {
-                    width: 1024,
-                    height: 768,
-                })
-            }
-            PhysicalKey::Code(KeyCode::Digit2) if modifiers.alt_key() => {
-                Some(InputAction::ResizeWindow {
-                    width: 1920,
-                    height: 1080,
-                })
-            }
-            PhysicalKey::Code(KeyCode::KeyI) => {
-                if modifiers.shift_key() {
-                    Some(InputAction::ToggleInfoOverlay)
-                } else {
-                    Some(InputAction::ShowInfoTemporary)
-                }
-            }
-            PhysicalKey::Code(KeyCode::KeyO) => {
-                if modifiers.shift_key() {
-                    Some(InputAction::ToggleFilenameDisplay)
-                } else {
-                    Some(InputAction::ShowFilenameTemporary)
-                }
-            }
-            PhysicalKey::Code(KeyCode::KeyL) => Some(InputAction::ToggleLoop),
-            PhysicalKey::Code(KeyCode::KeyA) => Some(InputAction::ToggleFitMode),
-            PhysicalKey::Code(KeyCode::KeyC)
-                if modifiers.control_key() && modifiers.shift_key() =>
-            {
-                Some(InputAction::CopyImageToClipboard)
-            }
-            PhysicalKey::Code(KeyCode::KeyC)
-                if modifiers.control_key() && !modifiers.shift_key() =>
-            {
-                Some(InputAction::CopyPathToClipboard)
-            }
-            PhysicalKey::Code(KeyCode::KeyE) if modifiers.alt_key() => {
-                Some(InputAction::OpenInExplorer)
-            }
-            PhysicalKey::Code(KeyCode::Slash) if modifiers.shift_key() => {
-                Some(InputAction::ToggleHelpOverlay)
-            }
-            PhysicalKey::Code(KeyCode::KeyG) => Some(InputAction::ToggleGallery),
-            PhysicalKey::Code(KeyCode::KeyZ) => Some(InputAction::ResetZoom),
-            _ => None,
-        };
+                PhysicalKey::Code(KeyCode::KeyG) => Some(InputAction::ToggleGallery),
+                PhysicalKey::Code(KeyCode::KeyZ) => Some(InputAction::ResetZoom),
+                _ => None,
+            };
 
         (action.is_some(), action)
     }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -412,9 +412,9 @@ impl EguiOverlay {
 
                             ui.add_space(4.0);
                             ui.heading("Window Resize");
-                            ui.label("Alt+0              Configured default size");
-                            ui.label("Alt+1              1024x768");
-                            ui.label("Alt+2              1920x1080 (Full HD)");
+                            ui.label("Alt+0              Half image size");
+                            ui.label("Alt+1              Original image size (1:1 pixels)");
+                            ui.label("Alt+2              Double image size");
 
                             ui.add_space(4.0);
                             ui.heading("Color Adjustments");


### PR DESCRIPTION
## Summary

Replaces the fixed-resolution window resize presets with mpv-style image-relative sizing:

| Key | Before | After |
|-----|--------|-------|
| Alt+0 | Configured default size | Half image size |
| Alt+1 | 1024x768 | Original image size (1:1 pixels) |
| Alt+2 | 1920x1080 (Full HD) | Double image size |

Keys are no-ops when no image is loaded (e.g. at startup).

## Implementation

- Added `current_image_size: Option<(u32, u32)>` to `InputContext` in `src/input.rs`
- Populated from `texture_manager.get_current_texture().map(|t| (t.width, t.height))` in `src/app.rs`
- Removed now-unused `window_default_size` from `InputContext` (and its construction)
- Updated help overlay text in `src/overlay.rs` to reflect new semantics

## Test plan

- [x] Load an image; press Alt+1 — window resizes to match image pixel dimensions
- [x] Press Alt+0 — window resizes to half the image size
- [x] Press Alt+2 — window resizes to double the image size
- [x] Press any Alt+0/1/2 with no image loaded — no crash, no resize
- [x] Help overlay (?) shows updated descriptions
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

Closes #220
