### PR TITLE
fix: add missing shortcuts to Keyboard Help overlay

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -427,6 +427,9 @@ impl EguiOverlay {
                             ui.heading("Actions");
                             ui.label("S                  Take screenshot");
                             ui.label("Ctrl+Shift+C       Copy image to clipboard");
+                            ui.label("Ctrl+C             Copy path to clipboard");
+                            ui.label("G                  Toggle Gallery");
+                            ui.label("Alt+E              Open in Explorer");
                             ui.label("?                  Toggle this help");
                             ui.label("Escape             Close this help");
 


### PR DESCRIPTION
## Summary

Adds three missing keyboard shortcuts to the Keyboard Help overlay Actions section:

- `Ctrl+C` — Copy path to clipboard
- `G` — Toggle Gallery
- `Alt+E` — Open in Explorer

> Note: `Alt+0/1/2` (image-relative resize) descriptions are added separately by #220 (PR #223).

## Test plan

- [x] Press `?` to open help overlay
- [x] Confirm new entries appear in the Actions section
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

Closes #207
