### PR TITLE
fix: remove pending_resize deferral to eliminate intermittent resize stutter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -78,10 +78,6 @@ pub struct ApplicationState {
     // Zoom/pan state
     zoom_scale: f32,
     zoom_pan: [f32; 2],
-
-    // Deferred resize — set on WindowEvent::Resized, applied at the start of render()
-    // to avoid reconfiguring the surface on every rapid resize event.
-    pending_resize: Option<winit::dpi::PhysicalSize<u32>>,
 }
 
 struct ActiveTransition {
@@ -199,7 +195,6 @@ impl ApplicationState {
             cached_info_string: None,
             zoom_scale: 1.0,
             zoom_pan: [0.0, 0.0],
-            pending_resize: None,
         };
 
         state.update_window_title();
@@ -983,11 +978,6 @@ impl ApplicationState {
     }
 
     fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
-        // Apply any deferred resize before touching the surface.
-        if let Some(new_size) = self.pending_resize.take() {
-            self.resize(new_size);
-        }
-
         let output = self.renderer.surface.get_current_texture()?;
         let view = output
             .texture
@@ -1223,14 +1213,16 @@ impl ApplicationHandler for ApplicationState {
                 match event {
                     WindowEvent::CloseRequested => event_loop.exit(),
                     WindowEvent::Resized(physical_size) => {
-                        // Defer surface reconfiguration to the next render() call.
-                        // During a live window drag the OS fires many Resized events
-                        // per frame; reconfiguring the surface on each one causes
-                        // visible stuttering. Storing only the latest size here
-                        // collapses all intermediate events into a single resize that
-                        // is applied once, right before the next frame is drawn.
-                        self.pending_resize = Some(physical_size);
-                        self.window.request_redraw();
+                        // Apply the resize immediately so the surface dimensions always
+                        // match the window before the next render() call. The previous
+                        // approach of deferring configure() to render() via pending_resize
+                        // caused a GPU pipeline stall: configure() and get_current_texture()
+                        // were called back-to-back in the same frame, producing an
+                        // intermittent hitch on every resize event (#219). Now that
+                        // SurfaceError::Outdated is handled identically to Lost (#221),
+                        // any stale-surface condition is recovered cleanly in the render
+                        // error path without needing deferral.
+                        self.resize(physical_size);
                     }
                     WindowEvent::ScaleFactorChanged {
                         scale_factor,


### PR DESCRIPTION
Closes #219

## Overview

Removes the `pending_resize` deferral introduced in #216. That approach
called `surface.configure()` and `get_current_texture()` back-to-back in
the same `render()` frame, causing a GPU pipeline stall that produced the
intermittent hitch seen during window drag. With `SurfaceError::Outdated`
now handled identically to `Lost` (#221), the deferral is no longer
necessary: resize is applied immediately in `WindowEvent::Resized` and any
stale-surface condition is recovered cleanly in the render error path.

## Changes

- Remove `pending_resize: Option<PhysicalSize<u32>>` field from `ApplicationState`
- Remove deferred `self.resize()` block at the top of `render()`
- `WindowEvent::Resized` now calls `self.resize(physical_size)` directly instead of storing into `pending_resize`
- Update inline comment to explain the rationale referencing both #219 and #221

## Testing

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes (no warnings)
- [x] `cargo test --all-features` passes (7/7)
- [x] `cargo build --release` succeeds
- [ ] Manual: drag window border at various speeds — verify no visible hitches
