### PR TITLE
feat: add Scan Subfolders checkbox and Transition Mode slider to Settings panel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -820,11 +820,17 @@ impl ApplicationState {
                 OverlayAction::SetPauseAtLast(_) => {
                     // Config already updated, just accessed by slideshow next frame
                 }
+                OverlayAction::ToggleScanSubfolders(_) => {
+                    // Config already updated; takes effect on next drop/load
+                }
                 OverlayAction::SetTransitionTime(_) => {
                     // Config already updated
                 }
                 OverlayAction::ToggleRandomTransition(_) => {
                     // Config already updated
+                }
+                OverlayAction::SetTransitionMode(_) => {
+                    // Config already updated; picked up by next transition
                 }
                 OverlayAction::SetFitMode(_) | OverlayAction::SetAmbientBlur(_) => {
                     // Config updated, will be picked up by render uniforms next frame

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -22,8 +22,10 @@ pub enum OverlayAction {
     SetTimer(f32),
     ToggleShuffle(bool),
     SetPauseAtLast(bool),
+    ToggleScanSubfolders(bool),
     SetTransitionTime(f32),
     ToggleRandomTransition(bool),
+    SetTransitionMode(i32),
     SetFitMode(FitMode),
     SetAmbientBlur(f32),
     ToggleAlwaysOnTop(bool),
@@ -476,6 +478,14 @@ impl EguiOverlay {
                     {
                         action = Some(OverlayAction::SetPauseAtLast(config.viewer.pause_at_last));
                     }
+                    if ui
+                        .checkbox(&mut config.viewer.scan_subfolders, "Scan Subfolders")
+                        .changed()
+                    {
+                        action = Some(OverlayAction::ToggleScanSubfolders(
+                            config.viewer.scan_subfolders,
+                        ));
+                    }
 
                     ui.separator();
                     ui.heading("Transition");
@@ -500,7 +510,18 @@ impl EguiOverlay {
                             config.transition.random,
                         ));
                     }
-                    // TODO: Mode dropdown if not random
+                    if !config.transition.random {
+                        ui.horizontal(|ui| {
+                            ui.label("Transition Mode:");
+                            if ui
+                                .add(egui::Slider::new(&mut config.transition.mode, 0..=19))
+                                .changed()
+                            {
+                                action =
+                                    Some(OverlayAction::SetTransitionMode(config.transition.mode));
+                            }
+                        });
+                    }
 
                     ui.separator();
                     ui.heading("Display");


### PR DESCRIPTION
Closes #205

## Overview

Adds two missing runtime controls to the Settings overlay so users can toggle `scan_subfolders` and choose a specific transition effect without editing the `.sldshow` file.

## Changes

- `src/overlay.rs`: Added two new `OverlayAction` variants (`ToggleScanSubfolders`, `SetTransitionMode`) and the corresponding UI widgets:
  - **Playback section**: Checkbox "Scan Subfolders" (reflects `config.viewer.scan_subfolders`); takes effect on the next drag-and-drop or folder load.
  - **Transition section**: `egui::Slider` (0-19) "Transition Mode", shown only when "Random Transitions" is unchecked; resolves the existing `// TODO: Mode dropdown if not random` comment.
- `src/app.rs`: Added two no-op match arms for the new action variants (config already updated by the time the action fires, same pattern as `SetPauseAtLast`).

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7 tests)
- [x] `cargo build --release` passed
- [x] Manual: open Settings, verify Scan Subfolders checkbox toggles correctly; uncheck Random Transitions and verify Transition Mode slider appears (0-19) and is hidden when Random is re-enabled.

Manual test command:
```
cargo run --release -- test.sldshow
```
