### PR TITLE
feat: append dropped folders to exist playlist when shift is held

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -873,15 +873,24 @@ impl ApplicationState {
                         new_paths.shuffle(&mut rand::rng());
                     }
                     let count = new_paths.len();
-                    self.texture_manager.replace_paths(new_paths);
-                    self.transition = None;
-                    self.renderer.invalidate_bind_group();
-                    self.current_texture_index = if count > 0 { Some(0) } else { None };
-                    self.slideshow.reset();
+
+                    if self.modifiers.shift_key() {
+                        self.texture_manager.append_paths(new_paths);
+                        // If it was already playing a slideshow/sequence, don't reset index to 0 or interrupt.
+                        self.show_osd(format!("Appended {} images", count));
+                        info!("Drag & drop: appended {} images", count);
+                    } else {
+                        self.texture_manager.replace_paths(new_paths);
+                        self.transition = None;
+                        self.renderer.invalidate_bind_group();
+                        self.current_texture_index = if count > 0 { Some(0) } else { None };
+                        self.slideshow.reset();
+                        self.show_osd(format!("Loaded {} images", count));
+                        info!("Drag & drop: loaded {} images", count);
+                    }
+
                     self.update_window_title();
                     self.cached_info_string = None;
-                    self.show_osd(format!("Loaded {} images", count));
-                    info!("Drag & drop: loaded {} images", count);
                 }
                 Err(e) => {
                     warn!("Drag & drop scan failed: {}", e);

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -167,6 +167,18 @@ impl TextureManager {
         while self.rx.try_recv().is_ok() {}
     }
 
+    /// Append paths to the existing image list, preserving the current index and loaded textures.
+    pub fn append_paths(&mut self, new_paths: Vec<Utf8PathBuf>) {
+        if self.paths.is_empty() {
+            self.replace_paths(new_paths);
+            return;
+        }
+        self.original_paths.extend(new_paths.clone());
+        self.paths.extend(new_paths);
+        // Do not bump epoch or clear existing textures because the existing indices remain valid.
+        // The new images will naturally be fetched when navigated to.
+    }
+
     /// Detect framerate from EXR metadata if available.
     /// Returns the FPS from the first EXR file found in the path list.
     pub fn detect_sequence_fps(&self) -> Option<f32> {


### PR DESCRIPTION
Closes #206

## Overview
Adds the ability to append files and folders to the current playlist by holding Shift when dragging and dropping.

## Changes
- Modified `ApplicationState::update` and the Drop event handler to conditionally append paths instead of replacing when the `shift` modifier is active.
- Added `TextureManager::append_paths` to append multiple paths to the playlist without interrupting an active slideshow or sequence.

## Testing
- [x] All quality gate checks passed (see VERIFY.md)
- [x] Manual testing recommended
