### PR TITLE
feat: HDR output support with Rgba16Float swapchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Desktop.ini
 debug_screenshots/
 sldshow-shot*.png
 
+# Generated test assets
+tools/test_hdr_gradient.exr
+
 # Temporary files
 nul
 *.tmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sldshow2"
 version = "0.2.0"
 edition = "2024"
+default-run = "sldshow2"
 rust-version = "1.85"
 authors = ["ugai"]
 description = "Simple slideshow image viewer with custom WGSL transitions"
@@ -56,6 +57,7 @@ kamadak-exif = "0.6.1"
 font-loader = "0.11.0"
 egui-phosphor = "0.10"
 fast_image_resize = "5.1.4"
+half = "2"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [

--- a/assets/shaders/transition.wgsl
+++ b/assets/shaders/transition.wgsl
@@ -38,7 +38,7 @@ struct TransitionUniform {
     zoom_scale: f32,   // 1.0 = no zoom; > 1.0 = zoomed in
     zoom_pan_x: f32,     // UV-space pan offset X (split to avoid vec2 alignment padding)
     zoom_pan_y: f32,     // UV-space pan offset Y
-    _pad: f32,
+    display_mode: i32,   // 0 = SDR (clamp to [0,1]), 1 = HDR (allow > 1.0)
 }
 
 @group(0) @binding(0)
@@ -306,8 +306,12 @@ fn apply_color_adjustments(color: vec4<f32>) -> vec4<f32> {
     let luminance = dot(c, vec3<f32>(0.2126, 0.7152, 0.0722));
     c = mix(vec3<f32>(luminance), c, material.saturation);
 
-    // Clamp to valid range
-    c = clamp(c, vec3<f32>(0.0), vec3<f32>(1.0));
+    // Clamp to valid range (SDR) or pass through (HDR)
+    if material.display_mode == 0 {
+        c = clamp(c, vec3<f32>(0.0), vec3<f32>(1.0));
+    } else {
+        c = max(c, vec3<f32>(0.0));
+    }
 
     return vec4<f32>(c, color.a);
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,6 +123,7 @@ impl ApplicationState {
                 config.viewer.max_texture_size[1],
             ),
         );
+        texture_manager.is_hdr = renderer.is_hdr;
 
         // Scan images
         if let Err(e) =
@@ -1096,7 +1097,7 @@ impl ApplicationState {
                 ambient_blur: self.config.viewer.ambient_blur,
                 zoom_scale: self.zoom_scale,
                 zoom_pan: self.zoom_pan,
-                _pad: 0.0,
+                display_mode: if self.renderer.is_hdr { 1 } else { 0 },
             };
 
             self.renderer.queue.write_buffer(

--- a/src/bin/gen_hdr_test.rs
+++ b/src/bin/gen_hdr_test.rs
@@ -1,0 +1,68 @@
+//! Generate a half-float EXR test image for HDR swapchain verification.
+//!
+//! Produces `tools/test_hdr_gradient.exr` — a 1920×1080 linear-float image:
+//!   - Horizontal luminance gradient from 0.0 to 4.0 across the full width
+//!   - Reference patches at 1.0 (SDR white), 2.0×, and 4.0× peak brightness
+//!
+//! Usage:
+//!   cargo run --bin gen_hdr_test
+//!   $env:RUST_LOG="info"; cargo run --release -- tools/test_hdr_gradient.exr
+
+use std::path::PathBuf;
+
+use image::{Rgba, Rgba32FImage};
+
+const WIDTH: u32 = 1920;
+const HEIGHT: u32 = 1080;
+
+fn main() {
+    let output = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tools")
+        .join("test_hdr_gradient.exr");
+
+    let mut img = Rgba32FImage::new(WIDTH, HEIGHT);
+
+    // Horizontal gradient: column 0 → 0.0, column WIDTH-1 → 4.0
+    for (x, _y, px) in img.enumerate_pixels_mut() {
+        let v = x as f32 / (WIDTH - 1) as f32 * 4.0;
+        *px = Rgba([v, v, v, 1.0]);
+    }
+
+    // Reference patches at SDR white (1.0), 2× and 4× peak
+    let patch_w = WIDTH / 10;
+    let patch_h = HEIGHT / 6;
+    let patch_top = HEIGHT / 2 - patch_h / 2;
+
+    for &value in &[1.0_f32, 2.0, 4.0] {
+        let cx = ((value / 4.0) * (WIDTH - 1) as f32) as u32;
+        let patch_left = cx.saturating_sub(patch_w / 2).min(WIDTH - patch_w);
+
+        let outline_v = (value * 1.5).min(4.0);
+        let outline_top = patch_top.saturating_sub(2);
+        let outline_left = patch_left.saturating_sub(2);
+        let outline_bottom = (patch_top + patch_h + 2).min(HEIGHT);
+        let outline_right = (patch_left + patch_w + 2).min(WIDTH);
+
+        for y in outline_top..outline_bottom {
+            for x in outline_left..outline_right {
+                img.put_pixel(x, y, Rgba([outline_v, outline_v, outline_v, 1.0]));
+            }
+        }
+        for y in patch_top..patch_top + patch_h {
+            for x in patch_left..patch_left + patch_w {
+                img.put_pixel(x, y, Rgba([value, value, value, 1.0]));
+            }
+        }
+    }
+
+    std::fs::create_dir_all(output.parent().unwrap()).expect("Failed to create tools/ dir");
+    img.save(&output).expect("Failed to write EXR");
+
+    println!(
+        "Written: {}  ({}×{}, linear float32 RGBA EXR)",
+        output.display(),
+        WIDTH,
+        HEIGHT
+    );
+    println!("Test with:  cargo run --release -- tools/test_hdr_gradient.exr");
+}

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -23,12 +23,22 @@ pub struct LoadedTexture {
     pub height: u32,
 }
 
+/// Mip-chain data returned from the loader thread to the GPU upload path.
+pub enum MipData {
+    /// Standard 8-bit sRGB pixels (one element per mip level).
+    Sdr(Vec<image::RgbaImage>),
+    /// Linear 32-bit float pixels for HDR EXR files (one element per mip level).
+    Hdr(Vec<image::Rgba32FImage>),
+}
+
 pub struct TextureManager {
     pub paths: Vec<Utf8PathBuf>,
     pub current_index: usize,
     pub textures: HashMap<usize, LoadedTexture>,
     pub max_texture_size: (u32, u32),
     pub cache_extent: usize,
+    /// When true, EXR files are loaded as linear Rgba16Float GPU textures.
+    pub is_hdr: bool,
 
     // Original sort order for restoring when shuffle is turned off
     original_paths: Vec<Utf8PathBuf>,
@@ -39,8 +49,8 @@ pub struct TextureManager {
     // Incremented on every replace_paths / set_shuffle_enabled call so that
     // results from threads spawned in a previous generation are discarded.
     epoch: u64,
-    tx: Sender<(u64, usize, anyhow::Result<Vec<image::RgbaImage>>)>,
-    rx: Receiver<(u64, usize, anyhow::Result<Vec<image::RgbaImage>>)>,
+    tx: Sender<(u64, usize, anyhow::Result<MipData>)>,
+    rx: Receiver<(u64, usize, anyhow::Result<MipData>)>,
 }
 
 impl TextureManager {
@@ -52,6 +62,7 @@ impl TextureManager {
             textures: HashMap::new(),
             max_texture_size,
             cache_extent,
+            is_hdr: false,
             original_paths: Vec::new(),
             loading_tasks: HashMap::new(),
             errors: HashMap::new(),
@@ -234,72 +245,146 @@ impl TextureManager {
                 self.loading_tasks.remove(&idx);
             }
             match result {
-                Ok(mips) => {
-                    let Some(base) = mips.first() else {
-                        error!("Image {} returned empty mip chain", idx);
-                        self.errors.insert(idx, "empty mip chain".to_string());
-                        continue;
-                    };
-                    let width = base.width();
-                    let height = base.height();
+                Ok(mip_data) => {
+                    match mip_data {
+                        MipData::Sdr(mips) => {
+                            let Some(base) = mips.first() else {
+                                error!("Image {} returned empty SDR mip chain", idx);
+                                self.errors.insert(idx, "empty mip chain".to_string());
+                                continue;
+                            };
+                            let width = base.width();
+                            let height = base.height();
 
-                    let texture_size = wgpu::Extent3d {
-                        width,
-                        height,
-                        depth_or_array_layers: 1,
-                    };
+                            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                                label: Some(&format!("Image Texture {}", idx)),
+                                size: wgpu::Extent3d {
+                                    width,
+                                    height,
+                                    depth_or_array_layers: 1,
+                                },
+                                mip_level_count: mips.len() as u32,
+                                sample_count: 1,
+                                dimension: wgpu::TextureDimension::D2,
+                                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                                    | wgpu::TextureUsages::COPY_DST,
+                                view_formats: &[],
+                            });
 
-                    let texture = device.create_texture(&wgpu::TextureDescriptor {
-                        label: Some(&format!("Image Texture {}", idx)),
-                        size: texture_size,
-                        mip_level_count: mips.len() as u32,
-                        sample_count: 1,
-                        dimension: wgpu::TextureDimension::D2,
-                        format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                        view_formats: &[],
-                    });
+                            for (level, mip) in mips.iter().enumerate() {
+                                queue.write_texture(
+                                    wgpu::TexelCopyTextureInfo {
+                                        texture: &texture,
+                                        mip_level: level as u32,
+                                        origin: wgpu::Origin3d::ZERO,
+                                        aspect: wgpu::TextureAspect::All,
+                                    },
+                                    mip,
+                                    wgpu::TexelCopyBufferLayout {
+                                        offset: 0,
+                                        bytes_per_row: Some(4 * mip.width()),
+                                        rows_per_image: Some(mip.height()),
+                                    },
+                                    wgpu::Extent3d {
+                                        width: mip.width(),
+                                        height: mip.height(),
+                                        depth_or_array_layers: 1,
+                                    },
+                                );
+                            }
 
-                    for (level, mip) in mips.iter().enumerate() {
-                        queue.write_texture(
-                            wgpu::TexelCopyTextureInfo {
-                                texture: &texture,
-                                mip_level: level as u32,
-                                origin: wgpu::Origin3d::ZERO,
-                                aspect: wgpu::TextureAspect::All,
-                            },
-                            mip,
-                            wgpu::TexelCopyBufferLayout {
-                                offset: 0,
-                                bytes_per_row: Some(4 * mip.width()),
-                                rows_per_image: Some(mip.height()),
-                            },
-                            wgpu::Extent3d {
-                                width: mip.width(),
-                                height: mip.height(),
-                                depth_or_array_layers: 1,
-                            },
-                        );
+                            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+                            self.textures.insert(
+                                idx,
+                                LoadedTexture {
+                                    texture,
+                                    view,
+                                    width,
+                                    height,
+                                },
+                            );
+                            debug!(
+                                "Uploaded SDR image {} ({}x{}, {} mips)",
+                                idx,
+                                width,
+                                height,
+                                mips.len()
+                            );
+                        }
+                        MipData::Hdr(mips) => {
+                            let Some(base) = mips.first() else {
+                                error!("Image {} returned empty HDR mip chain", idx);
+                                self.errors.insert(idx, "empty mip chain".to_string());
+                                continue;
+                            };
+                            let width = base.width();
+                            let height = base.height();
+
+                            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                                label: Some(&format!("Image Texture {} (HDR)", idx)),
+                                size: wgpu::Extent3d {
+                                    width,
+                                    height,
+                                    depth_or_array_layers: 1,
+                                },
+                                mip_level_count: mips.len() as u32,
+                                sample_count: 1,
+                                dimension: wgpu::TextureDimension::D2,
+                                format: wgpu::TextureFormat::Rgba16Float,
+                                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                                    | wgpu::TextureUsages::COPY_DST,
+                                view_formats: &[],
+                            });
+
+                            for (level, mip) in mips.iter().enumerate() {
+                                // Convert f32 → f16 for Rgba16Float GPU upload
+                                let f16_bytes: Vec<u8> = mip
+                                    .as_raw()
+                                    .iter()
+                                    .flat_map(|&f| half::f16::from_f32(f).to_ne_bytes())
+                                    .collect();
+                                queue.write_texture(
+                                    wgpu::TexelCopyTextureInfo {
+                                        texture: &texture,
+                                        mip_level: level as u32,
+                                        origin: wgpu::Origin3d::ZERO,
+                                        aspect: wgpu::TextureAspect::All,
+                                    },
+                                    &f16_bytes,
+                                    wgpu::TexelCopyBufferLayout {
+                                        offset: 0,
+                                        // 4 channels × 2 bytes (f16)
+                                        bytes_per_row: Some(8 * mip.width()),
+                                        rows_per_image: Some(mip.height()),
+                                    },
+                                    wgpu::Extent3d {
+                                        width: mip.width(),
+                                        height: mip.height(),
+                                        depth_or_array_layers: 1,
+                                    },
+                                );
+                            }
+
+                            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+                            self.textures.insert(
+                                idx,
+                                LoadedTexture {
+                                    texture,
+                                    view,
+                                    width,
+                                    height,
+                                },
+                            );
+                            debug!(
+                                "Uploaded HDR image {} ({}x{}, {} mips)",
+                                idx,
+                                width,
+                                height,
+                                mips.len()
+                            );
+                        }
                     }
-
-                    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-
-                    self.textures.insert(
-                        idx,
-                        LoadedTexture {
-                            texture,
-                            view,
-                            width,
-                            height,
-                        },
-                    );
-                    debug!(
-                        "Uploaded image {} ({}x{}, {} mips)",
-                        idx,
-                        width,
-                        height,
-                        mips.len()
-                    );
                 }
                 Err(e) => {
                     error!("Failed to load image {}: {}", idx, e);
@@ -337,22 +422,27 @@ impl TextureManager {
                     let tx = self.tx.clone();
                     let max_size = self.max_texture_size;
                     let epoch = self.epoch;
+                    let is_hdr = self.is_hdr;
 
                     self.loading_tasks.insert(idx, self.epoch);
 
                     rayon::spawn(move || {
-                        let res = std::panic::catch_unwind(|| load_image_rgba(&path, max_size))
-                            .unwrap_or_else(|payload| {
-                                let msg = if let Some(s) = payload.downcast_ref::<String>() {
-                                    s.clone()
-                                } else if let Some(s) = payload.downcast_ref::<&str>() {
-                                    (*s).to_owned()
-                                } else {
-                                    "unknown panic in image loader thread".to_owned()
-                                };
-                                error!("Image loader thread panicked for index {}: {}", idx, msg);
-                                Err(anyhow::anyhow!("loader thread panicked: {}", msg))
-                            });
+                        let res =
+                            std::panic::catch_unwind(|| load_image_mips(&path, max_size, is_hdr))
+                                .unwrap_or_else(|payload| {
+                                    let msg = if let Some(s) = payload.downcast_ref::<String>() {
+                                        s.clone()
+                                    } else if let Some(s) = payload.downcast_ref::<&str>() {
+                                        (*s).to_owned()
+                                    } else {
+                                        "unknown panic in image loader thread".to_owned()
+                                    };
+                                    error!(
+                                        "Image loader thread panicked for index {}: {}",
+                                        idx, msg
+                                    );
+                                    Err(anyhow::anyhow!("loader thread panicked: {}", msg))
+                                });
                         if tx.send((epoch, idx, res)).is_err() {
                             warn!("Failed to send loaded image {} (receiver dropped)", idx);
                         }
@@ -405,7 +495,7 @@ fn fast_resize(
         .ok_or_else(|| anyhow::anyhow!("from_raw failed"))
 }
 
-fn load_image_rgba(path: &Utf8Path, max_size: (u32, u32)) -> anyhow::Result<Vec<image::RgbaImage>> {
+fn load_image_mips(path: &Utf8Path, max_size: (u32, u32), is_hdr: bool) -> anyhow::Result<MipData> {
     use std::fs::File;
     use std::io::{BufReader, Seek, SeekFrom};
 
@@ -419,64 +509,88 @@ fn load_image_rgba(path: &Utf8Path, max_size: (u32, u32)) -> anyhow::Result<Vec<
         .seek(SeekFrom::Start(0))
         .map_err(|e| anyhow::anyhow!("Failed to seek image: {}", e))?;
 
-    let mut img = image::ImageReader::new(&mut reader)
+    let img = image::ImageReader::new(&mut reader)
         .with_guessed_format()
         .map_err(|e| anyhow::anyhow!("Failed to guess image format: {}", e))?
         .decode()
         .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
 
-    // If it's EXR (linear HDR), we need to tonemap or convert to sRGB locally
-    // since our WGPU format is Rgba8UnormSrgb and expects sRGB input values.
-    if path.extension().unwrap_or("").eq_ignore_ascii_case("exr") {
-        // Apply the IEC 61966-2-1 piecewise sRGB transfer function per channel
-        let mut rgba32f = img.into_rgba32f();
-        for pixel in rgba32f.pixels_mut() {
-            pixel[0] = linear_to_srgb(pixel[0].max(0.0));
-            pixel[1] = linear_to_srgb(pixel[1].max(0.0));
-            pixel[2] = linear_to_srgb(pixel[2].max(0.0));
-            // Alpha remains linear
+    let is_exr = path.extension().unwrap_or("").eq_ignore_ascii_case("exr");
+
+    if is_hdr && is_exr {
+        // HDR path: keep linear float data as Rgba32F, skip sRGB conversion.
+        // GPU upload will convert f32 → f16 for Rgba16Float texture.
+        let rgba32f = img.into_rgba32f();
+        let img = apply_orientation(image::DynamicImage::ImageRgba32F(rgba32f), orientation);
+        let base = resize_for_gpu_hdr(img.into_rgba32f(), max_size.0, max_size.1);
+
+        // Generate mip chain using image::imageops (fast_image_resize is U8 only)
+        let mip_count = mip_level_count(base.width(), base.height());
+        let mut mips: Vec<image::Rgba32FImage> = Vec::with_capacity(mip_count as usize);
+        mips.push(base);
+
+        for _ in 1..mip_count {
+            let prev = mips.last().expect("mip chain is non-empty");
+            let new_w = (prev.width() / 2).max(1);
+            let new_h = (prev.height() / 2).max(1);
+            let resized =
+                image::imageops::resize(prev, new_w, new_h, image::imageops::FilterType::Triangle);
+            mips.push(resized);
         }
-        img = image::DynamicImage::ImageRgba32F(rgba32f);
+
+        Ok(MipData::Hdr(mips))
+    } else {
+        // SDR path: existing behavior — tonemap EXR to sRGB, upload as Rgba8UnormSrgb.
+        let mut img = img;
+        if is_exr {
+            // Apply the IEC 61966-2-1 piecewise sRGB transfer function per channel
+            let mut rgba32f = img.into_rgba32f();
+            for pixel in rgba32f.pixels_mut() {
+                pixel[0] = linear_to_srgb(pixel[0].max(0.0));
+                pixel[1] = linear_to_srgb(pixel[1].max(0.0));
+                pixel[2] = linear_to_srgb(pixel[2].max(0.0));
+                // Alpha remains linear
+            }
+            img = image::DynamicImage::ImageRgba32F(rgba32f);
+        }
+
+        let img = apply_orientation(img, orientation);
+        let base = resize_for_gpu(img, max_size.0, max_size.1)?.into_rgba8();
+
+        // Generate mipmap chain on CPU
+        let mip_count = mip_level_count(base.width(), base.height());
+        let mut mips = Vec::with_capacity(mip_count as usize);
+        mips.push(base);
+
+        for _ in 1..mip_count {
+            let prev = mips
+                .last()
+                .ok_or_else(|| anyhow::anyhow!("mip chain is empty"))?;
+            let new_w = (prev.width() / 2).max(1);
+            let new_h = (prev.height() / 2).max(1);
+
+            let mut prev_clone = prev.clone();
+
+            // Fast image resize wrapper creation
+            let src_image = fast_image_resize::images::Image::from_slice_u8(
+                prev.width(),
+                prev.height(),
+                prev_clone.as_mut(),
+                fast_image_resize::PixelType::U8x4,
+            )
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+            let resized = fast_resize(
+                src_image,
+                new_w,
+                new_h,
+                fast_image_resize::FilterType::Bilinear,
+            )?;
+            mips.push(resized);
+        }
+
+        Ok(MipData::Sdr(mips))
     }
-
-    // Apply EXIF rotation using the orientation already read above.
-    let img = apply_orientation(img, orientation);
-
-    let base = resize_for_gpu(img, max_size.0, max_size.1)?.into_rgba8();
-
-    // Generate mipmap chain on CPU
-    let mip_count = mip_level_count(base.width(), base.height());
-    let mut mips = Vec::with_capacity(mip_count as usize);
-    mips.push(base);
-
-    for _ in 1..mip_count {
-        let prev = mips
-            .last()
-            .ok_or_else(|| anyhow::anyhow!("mip chain is empty"))?;
-        let new_w = (prev.width() / 2).max(1);
-        let new_h = (prev.height() / 2).max(1);
-
-        let mut prev_clone = prev.clone();
-
-        // Fast image resize wrapper creation
-        let src_image = fast_image_resize::images::Image::from_slice_u8(
-            prev.width(),
-            prev.height(),
-            prev_clone.as_mut(),
-            fast_image_resize::PixelType::U8x4,
-        )
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-        let resized = fast_resize(
-            src_image,
-            new_w,
-            new_h,
-            fast_image_resize::FilterType::Bilinear,
-        )?;
-        mips.push(resized);
-    }
-
-    Ok(mips)
 }
 
 fn mip_level_count(width: u32, height: u32) -> u32 {
@@ -608,6 +722,28 @@ fn resize_for_gpu(
         fast_image_resize::FilterType::Lanczos3,
     )?;
     Ok(image::DynamicImage::ImageRgba8(resized))
+}
+
+/// Resize an HDR (Rgba32F) image to fit within max_width×max_height, preserving aspect ratio.
+/// Uses bilinear (Triangle) filter since fast_image_resize does not support float pixels.
+fn resize_for_gpu_hdr(
+    img: image::Rgba32FImage,
+    max_width: u32,
+    max_height: u32,
+) -> image::Rgba32FImage {
+    if max_width == 0 || max_height == 0 {
+        return img;
+    }
+    let (orig_w, orig_h) = (img.width(), img.height());
+    if orig_w <= max_width && orig_h <= max_height {
+        return img;
+    }
+    let scale_w = max_width as f32 / orig_w as f32;
+    let scale_h = max_height as f32 / orig_h as f32;
+    let scale = scale_w.min(scale_h);
+    let new_w = ((orig_w as f32 * scale).round() as u32).max(1);
+    let new_h = ((orig_h as f32 * scale).round() as u32).max(1);
+    image::imageops::resize(&img, new_w, new_h, image::imageops::FilterType::Triangle)
 }
 
 pub fn scan_image_paths(

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,12 +63,26 @@ fn main() -> Result<()> {
     };
 
     let args: Vec<String> = std::env::args().collect();
-    let config_path = args.get(1).map(Utf8PathBuf::from);
-    let config = Config::load_default(config_path).unwrap_or_else(|e| {
+
+    // First positional arg is a config file if it ends in ".sldshow"; otherwise
+    // all positional args are treated as image/folder paths and override
+    // viewer.image_paths in the loaded (or default) config.
+    let (config_path, cli_image_paths): (Option<Utf8PathBuf>, Vec<Utf8PathBuf>) =
+        match args.get(1).map(Utf8PathBuf::from) {
+            Some(p) if p.extension() == Some("sldshow") => (Some(p), vec![]),
+            Some(_) => (None, args[1..].iter().map(Utf8PathBuf::from).collect()),
+            None => (None, vec![]),
+        };
+
+    let mut config = Config::load_default(config_path).unwrap_or_else(|e| {
         error!("Failed to load config: {}", e);
         warn!("Using default configuration");
         Config::default()
     });
+
+    if !cli_image_paths.is_empty() {
+        config.viewer.image_paths = cli_image_paths;
+    }
 
     // Set up drag-and-drop channel and event loop with message hook
     let (drag_drop, drag_drop_tx) = DragDropHandler::new();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -20,6 +20,8 @@ pub struct Renderer {
     pub uniform_buffer: wgpu::Buffer,
     /// Recreated when textures change (transition start/end).
     pub bind_group: Option<wgpu::BindGroup>,
+    /// True when a 16-bit float (Rgba16Float) swapchain was selected.
+    pub is_hdr: bool,
 }
 
 impl Renderer {
@@ -59,12 +61,20 @@ impl Renderer {
             .context("Failed to create device")?;
 
         let caps = surface.get_capabilities(&adapter);
-        let config_format = caps
-            .formats
-            .iter()
-            .copied()
-            .find(|f| f.is_srgb())
-            .unwrap_or(caps.formats[0]);
+        let hdr_fmt = wgpu::TextureFormat::Rgba16Float;
+        let (config_format, is_hdr) = if caps.formats.contains(&hdr_fmt) {
+            info!("HDR swapchain selected: Rgba16Float");
+            (hdr_fmt, true)
+        } else {
+            let fmt = caps
+                .formats
+                .iter()
+                .copied()
+                .find(|f| f.is_srgb())
+                .unwrap_or(caps.formats[0]);
+            info!("SDR swapchain selected: {:?}", fmt);
+            (fmt, false)
+        };
 
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
@@ -120,7 +130,7 @@ impl Renderer {
             ambient_blur: config.viewer.ambient_blur,
             zoom_scale: 1.0,
             zoom_pan: [0.0, 0.0],
-            _pad: 0.0,
+            display_mode: 0,
         };
 
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -137,6 +147,7 @@ impl Renderer {
             pipeline,
             uniform_buffer,
             bind_group: None,
+            is_hdr,
         })
     }
 

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -28,7 +28,7 @@ pub struct TransitionUniform {
     // Zoom/pan: scale > 1.0 means zoomed in; pan is UV-space offset
     pub zoom_scale: f32,
     pub zoom_pan: [f32; 2],
-    pub _pad: f32,
+    pub display_mode: i32, // 0 = SDR (clamp), 1 = HDR (pass-through)
 }
 
 pub struct TransitionPipeline {


### PR DESCRIPTION
Closes #51

## Overview

Enables a 16-bit `Rgba16Float` swapchain when the display supports it, routes EXR files as linear float textures without tone-mapping, and removes the hard clamp in the shader so values > 1.0 reach the display.

## Changes

- **`src/renderer.rs`** — prefer `Rgba16Float` swapchain; add `pub is_hdr: bool`; log which path was selected
- **`src/image_loader.rs`** — add `MipData` enum (`Sdr`/`Hdr`); EXR files loaded as `Rgba32F` on HDR path, converted to f16 on GPU upload; SDR path unchanged
- **`src/transition.rs` / `transition.wgsl`** — rename `_pad` → `display_mode: i32`; shader clamps on SDR, passes through on HDR
- **`src/app.rs`** — wire `renderer.is_hdr → texture_manager.is_hdr`; set `display_mode` uniform from renderer state
- **`src/main.rs`** — accept image/folder paths directly on the CLI (`.sldshow` extension → config file, anything else → image paths)
- **`Cargo.toml`** — add `half = "2"` for f32→f16 conversion; `default-run = "sldshow2"`
- **`src/bin/gen_hdr_test.rs`** — new binary: generates a 0–4 nit EXR gradient with reference patches for visual HDR verification

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo build --release`
- [x] HDR swapchain confirmed on HDR display: `INFO sldshow2::renderer: HDR swapchain selected: Rgba16Float`
- [x] Gradient values > 1.0 visible as distinct luminance levels on HDR display

```powershell
cargo run --bin gen_hdr_test
cargo run --release -- tools/test_hdr_gradient.exr
```
