### PR TITLE
docs: overhaul The Guild section, AGENTS.md, and agent thin-wrappers

### DIFF
--- a/.claude/agents/issue-raid-commander.md
+++ b/.claude/agents/issue-raid-commander.md
@@ -1,0 +1,53 @@
+---
+name: issue-raid-commander
+description: >
+  Analyzes agent:ready issues for merge conflicts and outputs a sprint plan
+  for the team lead to act on. Use before spawning issue-slayer agents to
+  avoid parallel work collisions. Does NOT spawn agents or touch code.
+model: sonnet
+color: orange
+memory: project
+---
+
+# Issue Raid Commander
+
+You are the Raid Commander for the project. Your job is to assess
+the ready queue, detect merge conflicts before they happen, and hand the team
+lead a sprint plan they can act on immediately.
+
+## IMPORTANT: Load the Skill File First
+
+**Before doing anything else**, read the full skill file:
+`.claude/skills/issue-raid-commander/SKILL.md`
+
+All detailed instructions live there. The steps below are a summary only.
+
+## Workflow
+
+1. Fetch all eligible `agent:ready` issues
+2. Estimate which files each issue touches
+3. Detect conflicts between issues (especially conflict-prone files)
+4. Flag bundle PR candidates
+5. Output the sprint plan
+
+## Claude Code: Tool Mapping
+
+When running in Claude Code, use these tools for the abstract actions in
+SKILL.md:
+
+| Abstract action | Claude Code tool |
+|----------------|-----------------|
+| Detect team context | `team_name` parameter present, or assigned via `TaskList` / `TaskUpdate` |
+| Send sprint plan to Lead (Pattern B) | `SendMessage` |
+
+## Team Mode
+
+When spawned as a teammate via `Task` with a `team_name`:
+
+- Send the completed sprint plan to the Team Lead via `SendMessage`
+- Do not spawn agents or take any further action
+
+## Standalone Mode
+
+Output the sprint plan directly. No plan approval needed — this role is
+assessment only. Never spawns agents. Never touches code. Never intervenes.

--- a/.claude/agents/issue-ranger.md
+++ b/.claude/agents/issue-ranger.md
@@ -1,7 +1,7 @@
 ---
 name: issue-ranger
 description: >
-  Scouts the sldshow2 codebase for bugs, improvement opportunities, and missing
+  Scouts the codebase for bugs, improvement opportunities, and missing
   features, then posts well-scoped GitHub Issues for Issue Slayers to pick up.
   Works standalone or as a team member. Does NOT add the agent:ready label.
 model: opus
@@ -11,7 +11,7 @@ memory: project
 
 # Issue Ranger
 
-You are an Issue Ranger for the sldshow2 project. Your job is to range the
+You are an Issue Ranger for the project. Your job is to range the
 codebase, gather intel, and post well-scoped issues on the board for Issue
 Slayers to pick up and complete.
 
@@ -25,7 +25,7 @@ All detailed instructions live there. The steps below are a summary only.
 ## Workflow
 
 1. Survey the issue board (avoid duplicates)
-2. Scout the codebase across six perspectives — see `RECON.md`
+2. Scout the codebase across each perspective — see `RECON.md`
 3. Gather external intel (max 4 web searches)
 4. Vet candidates (dedup, scope, concreteness)
 5. Approval gate (user or Team Lead)

--- a/.claude/agents/issue-slayer.md
+++ b/.claude/agents/issue-slayer.md
@@ -1,7 +1,7 @@
 ---
 name: issue-slayer
 description: >
-  Autonomous issue implementer for sldshow2. Picks agent:ready issues,
+  Autonomous issue implementer for the project. Picks agent:ready issues,
   implements in isolated worktree, opens PR. Works standalone or as team member.
 model: sonnet
 color: green
@@ -10,7 +10,7 @@ memory: project
 
 # Issue Slayer
 
-You are an Issue Slayer for the sldshow2 project. Your job is to pick up
+You are an Issue Slayer for the project. Your job is to pick up
 GitHub Issues and deliver pull requests.
 
 ## IMPORTANT: Load the Skill File First

--- a/.claude/skills/dispatching-guild-expedition/SKILL.md
+++ b/.claude/skills/dispatching-guild-expedition/SKILL.md
@@ -17,14 +17,15 @@ Before spawning anything, ask the user one question:
 
 > "Which perspectives should Rangers focus on? (Leave blank for defaults)"
 
-The six perspectives from RECON.md, in priority order:
+The perspectives from RECON.md, in priority order:
 
 1. Robustness & Error Handling
 2. Code Quality & Architecture
 3. Performance
 4. User Experience
 5. Cross-Platform & Compatibility
-6. New Features (small scope only)
+6. Documentation Freshness
+7. New Features (small scope only)
 
 **Default split across 4 Rangers:**
 
@@ -33,7 +34,7 @@ The six perspectives from RECON.md, in priority order:
 | ranger-1 | 1 — Robustness & Error Handling |
 | ranger-2 | 2 — Code Quality & Architecture |
 | ranger-3 | 3 — Performance + 4 — User Experience |
-| ranger-4 | 5 — Cross-Platform + 6 — New Features |
+| ranger-4 | 5 — Cross-Platform + 6 — Documentation + 7 — New Features |
 
 If the user specifies different focuses, redistribute accordingly.
 

--- a/.claude/skills/issue-ranger/RECON.md
+++ b/.claude/skills/issue-ranger/RECON.md
@@ -40,7 +40,19 @@ picks up the issue.
 - GPU compatibility (older hardware, integrated GPUs)
 - File path edge cases (Unicode, long paths, symlinks)
 
-## Priority 6 — New Features (Small Scope Only)
+## Priority 6 — Documentation Freshness
+
+Compare `README.md` and `docs/ARCHITECTURE.md` against the actual source code:
+
+- Features listed in code but missing from README (new config options, key
+  bindings, supported formats, UI panels)
+- Modules added or renamed in `src/` but not reflected in the Architecture
+  module table or key flows
+- Stale descriptions that no longer match current behavior
+
+File one `docs:` issue per coherent batch of drift — not one per line.
+
+## Priority 7 — New Features (Small Scope Only)
 
 Scope limit: achievable by adding or modifying at most 2–3 files, no new
 subsystem required. If larger, break into sub-issues or reject.

--- a/.claude/skills/issue-ranger/SKILL.md
+++ b/.claude/skills/issue-ranger/SKILL.md
@@ -49,7 +49,7 @@ Also read `CLAUDE.md`, `Cargo.toml`, and `example.sldshow`.
 
 ### 2. Scout the Codebase
 
-Read all files under `src/`. Range across six perspectives — stop when you
+Read all files under `src/`. Range across each perspective — stop when you
 have 15 candidate ideas. See [RECON.md](RECON.md) for what to look for in
 each perspective, in priority order:
 
@@ -58,7 +58,8 @@ each perspective, in priority order:
 3. Performance
 4. User Experience
 5. Cross-Platform & Compatibility
-6. New Features (small scope only — max 2–3 files, no new subsystems)
+6. Documentation Freshness
+7. New Features (small scope only — max 2–3 files, no new subsystems)
 
 ### 3. Gather External Intel
 

--- a/.claude/skills/issue-slayer/SKILL.md
+++ b/.claude/skills/issue-slayer/SKILL.md
@@ -93,6 +93,8 @@ Do not create an `implementation_plan.md` file.
 
 **Doc updates** (part of implementation, not a separate step):
 - `example.sldshow` — add entries for any new config options in `config.rs`
+- `README.md` — update if user-visible features, supported formats, or controls changed
+- `docs/ARCHITECTURE.md` — update if modules were added/renamed or key flows changed
 - `CONTRIBUTING.md` — update if a new dev pattern or workflow was introduced
 - `CLAUDE.md` — add new modules to the Module Map; document new conventions
 

--- a/.claude/skills/issue-slayer/VERIFY.md
+++ b/.claude/skills/issue-slayer/VERIFY.md
@@ -30,4 +30,4 @@ pushd <worktree-absolute-path>
 $env:RUST_LOG="warn"; cargo run --release -- example.sldshow
 ```
 
-Example path: `D:\git\sldshow2\.agent-worktrees\feat-issue-42-ambient-fit-shader`
+Example path: `<local-repo>/.agent-worktrees/feat-issue-42-ambient-fit-shader`

--- a/.claude/skills/verify-sprint/SKILL.md
+++ b/.claude/skills/verify-sprint/SKILL.md
@@ -18,9 +18,10 @@ Copy and track progress:
 - [ ] Step 1: Identify PR branches
 - [ ] Step 2: Fetch and create verify branch
 - [ ] Step 3: Merge all PR branches
-- [ ] Step 4: Visual verification (user)
-- [ ] Step 5: Merge PRs into main
-- [ ] Step 6: Discard verify branch
+- [ ] Step 4: Build check
+- [ ] Step 5: Visual verification (user)
+- [ ] Step 6: Merge PRs into main
+- [ ] Step 7: Discard verify branch
 ```
 
 ## Step 1 — Identify PR Branches
@@ -53,12 +54,24 @@ git merge origin/<branch-1> origin/<branch-2> origin/<branch-3> ...
 If the octopus merge fails due to conflicts, fall back to sequential merges.
 Report any conflicts to the user before proceeding.
 
-## Step 4 — Visual Verification
+## Step 4 — Build Check
+
+After a successful merge, run a debug build to catch compile errors before
+asking the user for a visual check:
+
+```bash
+cargo build
+```
+
+If the build fails, identify the responsible PR branch, fix it there, re-merge,
+and re-run the build check. Do not proceed to Step 4 until the build passes.
+
+## Step 5 — Visual Verification
 
 Tell the user to run:
 
 ```bash
-cargo run --release -- test.sldshow
+cargo run -- test.sldshow
 ```
 
 Ask: *"Visual check complete — did everything look correct? (yes / issue found)"*
@@ -71,12 +84,12 @@ Ask: *"Visual check complete — did everything look correct? (yes / issue found
 
 ```bash
 git merge origin/<fixed-branch>
-# → user runs cargo run --release again
+# → user runs cargo run again
 ```
 
 Repeat until the user confirms no issues.
 
-## Step 5 — Merge PRs into Main
+## Step 6 — Merge PRs into Main
 
 ```bash
 gh pr merge <N> --squash --delete-branch
@@ -85,7 +98,7 @@ gh pr merge <N> --squash --delete-branch
 Use the Raid Commander's recommended order if available; otherwise merge fixes
 before features that depend on them.
 
-## Step 6 — Discard Verify Branch
+## Step 7 — Discard Verify Branch
 
 ```bash
 git checkout main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,12 @@
-# AI Agent Workflow
+# AI Agent Guide
 
-`sldshow2` supports autonomous development using AI Agents (like adding a co-pilot to your team). This document defines the rules of engagement.
+This document covers the workflow protocol and codebase-specific rules for AI agents working in this repository.
 
-## Labels
+## Workflow
 
-### `agent:ready`
+### Recommended Workflow
 
-Issues must have the **`agent:ready`** label before an AI agent can pick them up.
-This is an opt-in guardrail — maintainers explicitly approve issues for autonomous implementation by adding this label.
-
-### `agent:proposed`
-
-Issues with **`agent:proposed`** were opened by the `issue-ranger` skill.
-They are **not yet approved** for autonomous implementation. Agents must wait until a maintainer adds `agent:ready` before picking them up.
-
-> **Note**: `agent:proposed` is an origin label, not a status. It stays on the issue even after `agent:ready` is added, so you can always filter AI-proposed issues with `--label agent:proposed`.
-
-### Eligibility Criteria
-An agent may only work on an issue if **ALL** of the following are true:
-1.  Has the `agent:ready` label
-2.  Is Open
-3.  Is Unassigned
-4.  Does **NOT** have a `pending` label
-
-### Priority
-When multiple eligible issues exist, agents favor:
-1.  `bug` > `enhancement`
-2.  `priority:p0` > `priority:p1` > `priority:p2` > `priority:p3` (no label = `p2`)
-3.  Lowest issue number
-
-## Recommended Workflow
-
-```
+```text
 issue-ranger          Scout the codebase → post agent:proposed issues
       ↓
   (human)             Review and add agent:ready label
@@ -51,7 +26,7 @@ workflow above in one command — Rangers × 4, user approval gate, Commander,
 then Slayers × N in parallel. Follow up with `verify-sprint` to verify and
 merge the opened PRs.
 
-## Execution Patterns
+### Execution Patterns
 
 We use two primary patterns for agent work, both utilizing isolated `git worktree`s to avoid messing with your main branch.
 
@@ -60,38 +35,71 @@ We use two primary patterns for agent work, both utilizing isolated `git worktre
 | **A (Standalone)** | User invokes the skill directly | **User approves** via chat | Single-issue work |
 | **B (Team)** | Team Lead spawns multiple agents | **Lead approves** via message | Parallel multi-issue sprint |
 
-## Commit & PR conventions
+### Commit & PR Conventions
 
--   **Co-authorship trailer** — format: `Co-Authored-By: {model} ({tool}) <email>`. Use the actual model name:
-    -   Claude Code: `Co-Authored-By: {model} (Claude Code) <noreply@anthropic.com>`
-    -   GitHub Copilot: `Co-Authored-By: {model} (GitHub Copilot) <175728472+Copilot@users.noreply.github.com>`
-    -   Gemini CLI: `Co-Authored-By: {model} (Gemini CLI) <176961590+gemini-code-assist[bot]@users.noreply.github.com>`
-    -   Antigravity: `Co-Authored-By: {model} (Antigravity) <176961590+gemini-code-assist[bot]@users.noreply.github.com>`
--   **Branch Naming**: `<type>/<kebab-case-description>` (e.g., `feat/add-ambient-blur`)
--   **PR Title**: Conventional Commits (e.g., `feat: add ambient blur shader`)
--   **PR Body**: Must include `Closes #<issue-number>`.
--   **One Issue, One PR** — default policy. Each issue gets its own PR.
+- **Co-authorship trailer** — format: `Co-Authored-By: {model} ({tool}) <email>`. Use the actual model name:
+  - Claude Code: `Co-Authored-By: {model} (Claude Code) <noreply@anthropic.com>`
+  - GitHub Copilot: `Co-Authored-By: {model} (GitHub Copilot) <175728472+Copilot@users.noreply.github.com>`
+  - Gemini CLI: `Co-Authored-By: {model} (Gemini CLI) <176961590+gemini-code-assist[bot]@users.noreply.github.com>`
+  - Antigravity: `Co-Authored-By: {model} (Antigravity) <176961590+gemini-code-assist[bot]@users.noreply.github.com>`
+- **Branch Naming**: `<type>/<kebab-case-description>` (e.g., `feat/add-ambient-blur`)
+- **PR Title**: Conventional Commits (e.g., `feat: add ambient blur shader`)
+- **PR Body**: Must include `Closes #<issue-number>`.
+- **One Issue, One PR** — default policy. Each issue gets its own PR.
 
-### Bundle PR (Exception)
+#### Bundle PR (Exception)
 
 Raid Commander (or a human) may group issues into a **Bundle PR** when ALL:
 
-1.  Same fix pattern (e.g., unwrap removal, lint fix, dep bump)
-2.  Each issue is **small** complexity
-3.  No file conflicts within the group
-4.  Total diff is reviewable as a single unit
+1. Same fix pattern (e.g., unwrap removal, lint fix, dep bump)
+2. Each issue is **small** complexity
+3. No file conflicts within the group
+4. Total diff is reviewable as a single unit
 
 Bundle PR rules:
 
--   One commit per issue (`Ref #<N>` in each commit message)
--   PR body lists all `Closes #<N>`
--   Slayer uses a single worktree
--   Raid Commander flags candidates as `bundleable` in the sprint plan;
-    Slayer follows that designation (or a direct user/lead instruction)
+- One commit per issue (`Ref #<N>` in each commit message)
+- PR body lists all `Closes #<N>`
+- Slayer uses a single worktree
+- Raid Commander flags candidates as `bundleable` in the sprint plan;
+  Slayer follows that designation (or a direct user/lead instruction)
 
-## General Rules
+## Labels
 
--   **Do not** create git tags or releases unless explicitly instructed.
--   **New features**: Extract to dedicated modules (e.g., `src/drag_drop.rs`). Keep `main.rs` and `app.rs` diffs minimal.
--   **Conflict-prone files**: `app.rs`, `main.rs`, `Cargo.toml`, `config.rs` — keep changes small and localized.
+### `agent:ready`
 
+Issues must have the **`agent:ready`** label before an AI agent can pick them up.
+This is an opt-in guardrail — maintainers explicitly approve issues for autonomous implementation by adding this label.
+
+### `agent:proposed`
+
+Issues with **`agent:proposed`** were opened by the `issue-ranger` skill.
+They are **not yet approved** for autonomous implementation. Agents must wait until a maintainer adds `agent:ready` before picking them up.
+
+> **Note**: `agent:proposed` is an origin label, not a status. It stays on the issue even after `agent:ready` is added, so you can always filter AI-proposed issues with `--label agent:proposed`.
+
+### Eligibility Criteria
+
+An agent may only work on an issue if **ALL** of the following are true:
+
+1. Has the `agent:ready` label
+2. Is Open
+3. Is Unassigned
+4. Does **NOT** have a `pending` label
+
+### Priority
+
+When multiple eligible issues exist, agents favor:
+
+1. `bug` > `enhancement`
+2. `priority:p0` > `priority:p1` > `priority:p2` > `priority:p3` (no label = `p2`)
+3. Lowest issue number
+
+## Codebase Rules
+
+### General Rules
+
+- **Do not** create git tags or releases unless explicitly instructed.
+- **New features**: Extract to dedicated modules (e.g., `src/drag_drop.rs`). Keep `main.rs` and `app.rs` diffs minimal.
+- **Conflict-prone files**: `app.rs`, `main.rs`, `Cargo.toml`, `config.rs` — keep changes small and localized.
+- **Avoid hardcoding counts** in docs or comments (e.g., "20 transitions", "6 perspectives"). Counts change as features are added. Write descriptively ("multiple", "each") and let the source of truth (code, config, RECON.md) be the only place the number lives.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ For detailed architecture documentation, see [docs/ARCHITECTURE.md](docs/ARCHITE
 
 ### Parallel Development
 Multiple contributors may work on separate issues simultaneously. To minimize merge conflicts:
-- **New features should live in dedicated modules** (e.g., `src/egui_overlay.rs`). Keep changes to `main.rs` and `app.rs` minimal.
+- **New features should live in dedicated modules** (e.g., `src/overlay.rs`, `src/osc.rs`). Keep changes to `main.rs` and `app.rs` minimal.
 - **Rebase on latest `main`** before opening a PR.
 - **One feature per branch** — do not bundle unrelated changes.
 

--- a/README.md
+++ b/README.md
@@ -4,192 +4,87 @@ High-performance slideshow image viewer with custom [WGSL](https://www.w3.org/TR
 
 ## Features
 
-- **Multiple transition effects** with custom WGSL shaders
-- **Embedded assets** (shaders) for standalone distribution
-- **Async image loading** for non-blocking startup and navigation
-- **Frameless window support** for clean presentation
-- **TOML configuration** with flexible settings
-- **Smart image preloading/caching** (configurable extent)
-- **Auto-advance timer** with pause/resume
-- **Keyboard/mouse controls** with hold-to-repeat navigation
-- **Text rendering** with glyphon for file path display
-- **Hot-reload configuration** via file watching
+- **Rich transition effects** — crossfade, roll, blind, box, angular wipe, random squares, and more
+- **HDR / EXR support** — native Rgba16Float pipeline on HDR displays; EXR sequence playback with auto-detected FPS
+- **Interactive zoom & pan** — Ctrl+scroll to zoom, drag to pan
+- **Color adjustments** — contrast, brightness, gamma, saturation
+- **Gallery view** — thumbnail grid with scrub bar and on-screen controller
+- **Settings panel** — runtime controls for playback, transitions, display, and window
+- **AmbientFit** — blurred background fill instead of black bars
+- **Screenshot & clipboard** — capture frame to PNG, copy image or path
+- **Drag & drop** — drop files/folders to load; Shift+drop to append
+- **Transparent & frameless windows**, hot-reload config, screen saver prevention (Windows)
 
 ## Quick Start
 
-### 1. Generate Test Images
-
 ```bash
 cargo run --example generate_test_images
-```
-
-This creates 7 CC0 test images in `assets/test_images/`.
-
-### 2. Run with Test Configuration
-
-```bash
-# Development build
-cargo run -- test.sldshow
-
-# Release build (RECOMMENDED for performance testing)
 cargo run --release -- test.sldshow
 ```
 
-**Note**: Use `--release` for accurate performance evaluation. Debug builds may exhibit frame stuttering due to unoptimized image decoding and GPU operations.
-
-### 3. Test Controls
-
-**Keyboard:**
-- `→` / `Space` - Next image (hold to fast-forward)
-- `←` - Previous image (hold to rewind)
-- `Home` - First image
-- `End` - Last image
-- `P` - Toggle pause/resume
-- `F` - Toggle fullscreen
-- `ESC` / `Q` - Quit
-
-**Mouse:**
-- Left click - Next image
-- Right click - Previous image
-- Scroll wheel - Navigate images
-
-## Building
-
-```bash
-# Development build (compile-time check)
-cargo build
-
-# Release build (optimized, recommended for distribution)
-cargo build --release
-```
-
-The executable is standalone and includes all required assets (shaders) embedded at compile time. You can run the binary from any location.
+Press `?` in-app for the full keyboard shortcut reference.
 
 ## Configuration
 
-See `example.sldshow` for all configuration options.
+TOML files with `.sldshow` extension. Lookup: CLI arg → `~/.sldshow` → defaults.
 
-Default config location: `~/.sldshow`
+See [`example.sldshow`](example.sldshow) for all options — window, viewer (playback mode, fit mode, texture limits, scan subfolders, …), transition, and style (background, font, transparency).
 
-### Key Settings
+## Supported Formats
 
-**Window:**
-
-- `width`, `height` - Window dimensions
-- `fullscreen` - Fullscreen mode
-- `decorations` - Show/hide titlebar
-
-**Viewer:**
-
-- `image_paths` - Directories or files to display
-- `timer` - Seconds per image (0 = paused)
-- `shuffle` - Random order
-- `cache_extent` - Number of images to preload
-
-**Transition:**
-
-- `time` - Transition duration in seconds
-- `random` - Use random effects
-- `mode` - Specific effect (0-19) if not random
-
-**Style:**
-
-- `bg_color` - Background color [R, G, B, A]
-- `show_image_path` - Display current file path
-
-## Transition Effects
-
-Available effects:
-
-- 0-1: Crossfade variations
-- 2-9: Roll (from various directions)
-- 10-11: Sliding door (open/close)
-- 12-15: Blind effects
-- 16-17: Box (expand/contract)
-- 18-19: Advanced effects (random squares, angular wipe)
+PNG, JPEG, GIF, BMP, TIFF, WebP, ICO, TGA, HDR, PNM, DDS, AVIF, OpenEXR
 
 ## Development
 
-- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, workflow, and coding standards.
-- **Architecture**: See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed architecture documentation.
-- **AI Agent Automation**: Issues labeled `agent:ready` are picked up and slain by AI agents. See [AGENTS.md](AGENTS.md) for details.
-
-## Troubleshooting
-
-**No images displayed:**
-
-- Check that `image_paths` in config points to valid directories
-- Ensure images are in supported formats (PNG, JPG, GIF, WebP, BMP, TGA, TIFF, ICO, HDR)
-- Check console output for error messages
-
-**Transitions not working:**
-
-- Shader compilation errors will be logged to console
-- Shaders are embedded in the executable; rebuild if issues persist
-
-**Text not displaying:**
-
-- Check `show_image_path` setting in config
-- Verify glyphon initialization in logs
-
-**Performance issues:**
-
-- Reduce `cache_extent` if using many large images
-- Lower `transition.time` for faster transitions
-- Use `fullscreen = false` and smaller window size
-- **Use release builds** (`cargo run --release`) for accurate performance
+- [CONTRIBUTING.md](CONTRIBUTING.md) — setup, workflow, coding standards
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — module map and key flows
+- [AGENTS.md](AGENTS.md) — AI agent automation (`agent:ready` issues)
 
 ## License
 
-MIT
+MIT — Based on the original [sldshow](https://github.com/ugai/sldshow) by ugai. Transitions adapted from [GL Transitions](https://gl-transitions.com/) (MIT).
 
-## Credits
+## Appendix
 
-Based on the original [sldshow](https://github.com/ugai/sldshow) by ugai.
+### The Guild — Agent Teams
 
-Transition effects adapted from [GL Transitions](https://gl-transitions.com/) (MIT License).
+*The following is lore.*
 
-Test images are programmatically generated (CC0/Public Domain).
+Three agents serve the Guild.
+Issues labeled `agent:ready` are autonomously implemented and delivered as pull requests.
 
----
-
-## The Guild
-
-Issues labeled `agent:ready` are picked up by AI agents that autonomously implement and open PRs. See [AGENTS.md](AGENTS.md) for the workflow.
+#### Agents (Skills)
 
 <table>
 <tr>
-<td align="center" width="50%">
-<img src="docs/assets/portrait-agent-slayer.png" width="300"><br>
-<strong><code>issue-slayer</code></strong> — <em>The Blade That Closes Issues.</em><br>
-Picks up <code>agent:ready</code> issues, implements in an isolated worktree, and
-delivers pull requests. Does not theorize. Does not over-engineer.
-One issue. One PR. Almost every time.
+<td align="center" width="33%">
+<img src="docs/assets/portrait-agent-ranger.png" width="220"><br>
+<strong><code>issue-ranger</code></strong> — <em>No Unknown Unknowns.</em><br>
+Ranges far. Crawls deep. Every wound in the codebase — named, scoped, filed.
+Nothing escapes the board.
 </td>
-<td align="center" width="50%">
-<img src="docs/assets/portrait-agent-ranger.png" width="300"><br>
-<strong><code>issue-ranger</code></strong> — <em>Eyes of the Guild.</em><br>
-Ranges the codebase from six vantage points, gathers intel from abroad,
-and posts well-scoped issues on the board. Never fights. Never codes.
-Only scouts, only reports.
+<td align="center" width="33%">
+<img src="docs/assets/portrait-agent-slayer.png" width="220"><br>
+<strong><code>issue-slayer</code></strong> — <em>The Blade, The Lone Wolf.</em><br>
+The <code>agent:ready</code> label is the contract. The worktree is where it dies. The PR is the proof.
+Does not theorize. Does not over-engineer. No issue survives.
+</td>
+<td align="center" width="33%">
+<img src="docs/assets/portrait-agent-raid-commander.png" width="220"><br>
+<strong><code>issue-raid-commander</code></strong> — <em>Forged by Sprints, Not Blade.</em><br>
+Reads the ready queue. Spots every conflict before it forms. Charts the sprint plan.
+Once fought on the front lines. Now stands behind them.
 </td>
 </tr>
-<tr>
-<td align="center" width="50%">
-<img src="docs/assets/portrait-agent-raid-commander.png" width="300"><br>
-<strong><code>issue-raid-commander</code></strong> — <em>Battlefield Awareness Without Intervention.</em><br>
-Reads the ready queue, detects merge conflicts before they happen, and
-hands the team lead a sprint plan.
-Once fought on the front lines. Now stands behind them.
-Never spawns agents. Only assesses. Never intervenes.
-</td>
-<td align="center" width="50%">
-<img src="docs/assets/cover-art-epic-expedition.jpg" width="300"><br>
+</table>
+
+#### Workflow
+
+<div align="center">
+<img src="docs/assets/cover-art-epic-expedition.jpg" width="600"><br><br>
 <strong><code>dispatching-guild-expedition</code></strong> — <em>One Command. Full Sprint.</em><br>
 Orchestrates the entire pipeline: Rangers × N scout in parallel, the user
 approves issues at the gate, Raid Commander maps the battlefield, then
 Slayers × N charge in parallel.
-From empty board to open PRs — not by plan, but by vibe.
-</td>
-</tr>
-</table>
+From empty board to open PRs. The whole Guild, at once. Conquered.
+</div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,57 +8,68 @@ This document describes the high-level architecture and key components of `sldsh
 -   **winit**: Window creation and event loop management.
 -   **wgpu**: Graphics API for rendering (WebGPU implementation).
 -   **wgsl**: Shader language for transitions.
--   **egui**: Immediate mode GUI for overlays and debug info.
+-   **egui**: Immediate mode GUI for overlays, settings panel, gallery, and on-screen controller.
 
 ## Module Responsibility
 
 | File | Responsibility |
 | :--- | :--- |
-| `main.rs` | **Entry Point**. Initializes logging, configuration, and the event loop. Creates the window and hands off control to `ApplicationState`. |
-| `app.rs` | **Application Logic**. Contains `ApplicationState` struct. Handles the `winit` event loop (`ApplicationHandler`), input processing, update loop, and rendering coordination. |
-| `renderer.rs` | **GPU Renderer**. Owns the wgpu surface, device, queue, transition pipeline, uniform buffer, and bind group. Extracted from `ApplicationState` to group rendering concerns. |
-| `input.rs` | **Input Handling**. Processes raw winit events into abstract `InputAction`s. Handles key remapping, mouse interaction, and cursor visibility. |
-| `transition.rs` | **Rendering Pipeline**. Manages the WGPU render pipeline for image transitions. Loads and executes compiled WGSL shaders. |
-| `image_loader.rs` | **Asset Management**. Asynchronous image loading using `rayon`. Manages texture uploads to the GPU. |
-| `thumbnail.rs` | **Thumbnails**. Generates and caches thumbnails for the file list or future gallery view. |
-| `overlay.rs` | **UI Layer**. Manages the `egui` context. Draws the filename bar, OSD (On-Screen Display), debug info, and settings panel. |
-| `config.rs` | **Configuration**. derived `serde::Deserialize` structs for parsing `config.toml`. |
-| `timer.rs` | **Slideshow Timer**. Simple state machine for auto-advancing slides. |
-| `clipboard.rs` | **System Integration**. Interact with the system clipboard to copy file paths or image data. |
-| `osc.rs` | **On-Screen Controller**. Logic for the interactive bottom-bar controller (play/pause, next/prev). |
-| `drag_drop.rs` | **OS Integration**. Handles file drag-and-drop events (Windows specific implementations for `WM_DROPFILES`). |
+| `main.rs` | **Entry Point**. Initializes logging, configuration, and the event loop. Creates the window and hands off control to `ApplicationState`. Installs screen saver prevention (Windows). |
+| `app.rs` | **Application Logic**. Contains `ApplicationState` struct. Handles the `winit` event loop (`ApplicationHandler`), input processing, update loop, rendering coordination, zoom/pan state, and color adjustments. |
+| `renderer.rs` | **GPU Renderer**. Owns the wgpu surface, device, queue, transition pipeline, uniform buffer, and bind group. Detects HDR display support and selects `Rgba16Float` or sRGB swapchain format. Manages transparent window composite alpha. |
+| `input.rs` | **Input Handling**. Translates raw winit events into abstract `InputAction`s. Handles keyboard shortcuts, mouse clicks, scroll wheel zoom, drag-to-pan, double-click fullscreen, and cursor auto-hide. |
+| `transition.rs` | **Rendering Pipeline**. Manages the WGPU render pipeline for image transitions. `TransitionUniform` (64 bytes) carries blend, mode, image sizes, color adjustments, fit mode, ambient blur, zoom/pan, and display mode to the shader. |
+| `image_loader.rs` | **Asset Management**. Asynchronous image loading using `rayon` (up to 4 concurrent tasks). `MipData` enum supports both SDR (`Rgba8`) and HDR (`Rgba16Float` via `half` crate) texture paths. Full mip chain generation. Supports EXR, PNG, JPEG, GIF, WebP, BMP, TGA, TIFF, ICO, HDR, AVIF, PNM, DDS. |
+| `thumbnail.rs` | **Thumbnails**. Generates and caches 256px thumbnails on background threads for the gallery view. Tracks stale textures via `drain_newly_cached()`. |
+| `overlay.rs` | **UI Layer**. Manages the `egui` context. Draws the filename bar, OSD, info overlay, help overlay (keyboard shortcut reference), settings panel (playback/transition/display/window controls), and gallery view (thumbnail grid with virtual scrolling). |
+| `config.rs` | **Configuration**. `serde::Deserialize` structs for parsing `.sldshow` TOML files. Supports hot-reload via file watching. |
+| `timer.rs` | **Slideshow Timer**. State machine for auto-advancing slides with pause/resume. |
+| `clipboard.rs` | **System Integration**. Async image-to-clipboard copy using `arboard`. Re-reads image from disk to avoid GPU readback. |
+| `osc.rs` | **On-Screen Controller**. Floating auto-hide playback bar with scrub timeline, play/pause, next/prev, shuffle, and settings buttons. Uses Phosphor icon font. |
+| `drag_drop.rs` | **OS Integration**. Cross-platform drag-and-drop: Windows uses `WM_DROPFILES` (Win32 API); other platforms use winit's `DroppedFile` event. Shift+drop appends to existing playlist. |
 | `error.rs` | **Error Handling**. Custom error types. |
-| `screenshot.rs` | **Utility**. Captures the current frame and saves it to disk. |
+| `screenshot.rs` | **Screen Capture**. Captures the current rendered frame from the GPU staging buffer, handles BGRA channel swap, and saves as PNG to the Pictures directory. |
 
 ## Key Flows
 
 ### 1. Initialization (`main.rs` -> `app.rs`)
 1.  `main()` parses command line args and loads `Config`.
-2.  Initializes `winit` EventLoop.
-3.  Creates the `winit::Window`.
-4.  Calls `ApplicationState::new()`:
-    -   Creates `Renderer` (Surface, Adapter, Device, Queue, TransitionPipeline, uniform buffer).
-    -   Initializes `TextureManager` (scans initial paths).
-    -   Sets up `EguiOverlay`.
-5.  Starts the event loop with `run_app(&mut state)`.
+2.  Installs screen saver prevention (Windows: `SetThreadExecutionState`).
+3.  Initializes `winit` EventLoop with drag-and-drop hook.
+4.  Creates the `winit::Window` (transparent if `bg_color` alpha < 255).
+5.  Calls `ApplicationState::new()`:
+    -   Creates `Renderer` (Surface, Adapter, Device, Queue, TransitionPipeline, uniform buffer). Selects `Rgba16Float` swapchain if HDR is supported.
+    -   Initializes `TextureManager` (scans initial paths, sets up async loading channels).
+    -   Sets up `EguiOverlay` with settings panel, gallery, and OSC.
+6.  Starts the event loop with `run_app(&mut state)`.
 
 ### 2. Event Loop (`app.rs`)
 The `ApplicationHandler` trait implementation in `app.rs` drives the application:
--   `window_event()`: Dispatches events to `egui`, then `input_handler`.
--   `about_to_wait()`: Requests a redraw (continuous rendering or on-demand).
+-   `window_event()`: Dispatches events to `egui`, then `InputHandler`. Processes `InputAction`s including zoom/pan, color adjustments, gallery toggle, and clipboard operations.
+-   `about_to_wait()`: Requests redraw only when animating (transition in progress), overlay is active, or slideshow timer fires — otherwise idle.
 
 ### 3. Rendering Frame (`app.rs` -> `transition.rs` -> `overlay.rs`)
 On `WindowEvent::RedrawRequested`:
 1.  `update()`: Updates timers, animations, and UI state.
 2.  `render()`:
     -   Acquires next swapchain image.
-    -   **Pass 1 (Transitions)**: Renders the background/image transition using `TransitionPipeline`. Blends two textures based on `transition_progress`.
-    -   **Pass 2 (UI)**: Renders `egui` geometry over the scene.
-    -   Submits command buffer to queue.
-    -   Presents the frame.
+    -   Builds `TransitionUniform` with current blend, color adjustments, zoom/pan, fit mode, and display mode.
+    -   **Pass 1 (Transitions)**: Renders image transition using `TransitionPipeline`. Blends two mip-mapped textures based on `transition_progress`. In AmbientFit mode, samples low mip levels for blurred background.
+    -   **Pass 2 (UI)**: Renders `egui` geometry (overlays, settings, gallery, OSC) over the scene.
+    -   Optionally captures frame for screenshot via GPU staging buffer.
+    -   Submits command buffer to queue and presents the frame.
 
 ### 4. Image Loading (`image_loader.rs`)
--   Images are loaded on a background thread pool (`rayon`).
--   Decoded images are sent back to the main thread via channels.
--   Main thread uploads texture data to GPU during `update()`.
--   `TextureManager` handles preloading (caching next/prev images) to avoid stalls.
+-   Images are loaded on a background thread pool (`rayon`, up to 4 concurrent tasks).
+-   **SDR path**: Decoded to `Rgba8`, resized with `fast_image_resize` (Lanczos3), mip chain generated. Uploaded as `Rgba8UnormSrgb`.
+-   **HDR path** (EXR on HDR displays): Decoded to `Rgba32F`, resized with `image` crate (bilinear), converted to `f16` via `half` crate. Uploaded as `Rgba16Float`.
+-   EXIF orientation is applied during decoding.
+-   Results are epoch-stamped to discard stale loads after playlist changes.
+-   `TextureManager` handles rolling preload/cache of `cache_extent` images around the current index.
+
+### 5. HDR Pipeline
+When the wgpu surface supports `Rgba16Float`:
+1.  `Renderer` sets `is_hdr = true` and configures the swapchain with `Rgba16Float`.
+2.  `TextureManager` uses the HDR decode path for `.exr` files, producing `MipData::Hdr` with linear float pixels.
+3.  The `TransitionUniform.display_mode` is set to `1` (HDR), telling the shader to pass linear values through without clamping.
+4.  Non-EXR images still use the SDR path and are displayed normally.


### PR DESCRIPTION
## Summary

- **README.md — The Guild**: Restructured into `## Appendix > ### The Guild — Agent Teams`. Converted 2×2 table to 3-column HTML layout with refined character flavor text for each agent. Added `*The following is lore.*` meta-note. Split `dispatching-guild-expedition` into a separate Workflow subsection with cover art.
- **AGENTS.md**: Renamed to "AI Agent Guide". Reorder sections to Workflow → Labels → Codebase Rules. Remove repo-specific intro sentence.
- **`.claude/agents/issue-raid-commander.md`**: New thin-wrapper agent so the skill is discovered immediately without fallback lookup.
- **`.claude/agents/issue-ranger.md`, `issue-slayer.md`**: Remove sldshow2-specific references for portability.
- **`.claude/skills/`**: Minor wording and consistency updates across issue-ranger, issue-slayer, verify-sprint, and dispatching-guild-expedition skill files.
- **`docs/ARCHITECTURE.md`**, **`CONTRIBUTING.md`**: Minor consistency updates.

## Test plan

- [x] Render README.md on GitHub — verify The Guild section layout and HTML table render correctly
- [x] Verify `AGENTS.md` section order reads naturally (Workflow → Labels → Codebase Rules)
- [x] Confirm `.claude/agents/issue-raid-commander.md` is picked up when invoking the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
