### PR TITLE
fix: prevent stale bind group causing one-frame flash at transition start

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1070,7 +1070,16 @@ impl ApplicationState {
         let tex_b = self.texture_manager.get_texture(tex_b_idx);
 
         if let (Some(tex_a), Some(tex_b)) = (tex_a, tex_b) {
-            // Recreate bind group when textures change (transition start/end)
+            // Recreate bind group when textures change (transition start/end).
+            // Also invalidate if the requested indices differ from what was
+            // used to build the current bind group — this catches any case
+            // where the bind group was not explicitly invalidated but the
+            // active texture slots changed (e.g., a texture was reloaded or
+            // the transition skipped an explicit invalidation path).
+            if self.renderer.bound_tex_indices != Some((tex_a_idx, tex_b_idx)) {
+                self.renderer.bind_group = None;
+                self.renderer.bound_tex_indices = None;
+            }
             if self.renderer.bind_group.is_none() {
                 self.renderer.bind_group = Some(self.renderer.pipeline.create_bind_group(
                     &self.renderer.device,
@@ -1078,6 +1087,7 @@ impl ApplicationState {
                     &tex_a.view,
                     &tex_b.view,
                 ));
+                self.renderer.bound_tex_indices = Some((tex_a_idx, tex_b_idx));
             }
 
             // Update Uniforms

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -20,6 +20,10 @@ pub struct Renderer {
     pub uniform_buffer: wgpu::Buffer,
     /// Recreated when textures change (transition start/end).
     pub bind_group: Option<wgpu::BindGroup>,
+    /// The texture indices that `bind_group` was built from.
+    /// Used to detect when the active textures change so the bind group
+    /// is rebuilt even if it was not explicitly invalidated.
+    pub bound_tex_indices: Option<(usize, usize)>,
     /// True when a 16-bit float (Rgba16Float) swapchain was selected.
     pub is_hdr: bool,
 }
@@ -147,6 +151,7 @@ impl Renderer {
             pipeline,
             uniform_buffer,
             bind_group: None,
+            bound_tex_indices: None,
             is_hdr,
         })
     }
@@ -166,5 +171,6 @@ impl Renderer {
     /// Force the bind group to be recreated on the next frame.
     pub fn invalidate_bind_group(&mut self) {
         self.bind_group = None;
+        self.bound_tex_indices = None;
     }
 }


### PR DESCRIPTION
Closes #32

## Overview

Track which texture indices the bind group was built from so it is automatically
rebuilt whenever the active texture slots change, preventing a stale bind group
from being used on the first frame of a new transition.

## Root Cause

The bind group caching in `render()` only rebuilt the bind group when it was
explicitly set to `None` via `invalidate_bind_group()`. While `start_transition()`
always calls `invalidate_bind_group()`, there are edge cases where the bind group
object remains non-`None` but references the wrong textures for the current frame —
for example when a texture in the cache is replaced or the transition state changes
between the invalidation call and the next render. In these cases the stale bind
group (which could have `blend = 1.0` baked in from the previous frame's texture
layout) was used for one frame, producing the visible flash of the destination image.

## Changes

- `src/renderer.rs`: Added `bound_tex_indices: Option<(usize, usize)>` to `Renderer`
  to record which texture slot indices the current bind group was built for. Updated
  `invalidate_bind_group()` to clear the cached indices alongside the bind group.

- `src/app.rs`: In `render()`, compare the requested `(tex_a_idx, tex_b_idx)` against
  `bound_tex_indices` before using the cached bind group. If they differ, the bind
  group is dropped and rebuilt with the correct textures before the draw call. The
  indices are recorded whenever a new bind group is created.

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (7 tests)
- [x] `cargo build --release` passed
- [ ] Manual visual testing: run `cargo run --release -- test.sldshow` with a short
  timer (1 second) and verify the destination-image flash no longer appears at
  transition start
