### PR TITLE
fix: correct inverted sliding_door close transition (mode 11)

### DIFF
--- a/assets/shaders/transition.wgsl
+++ b/assets/shaders/transition.wgsl
@@ -196,18 +196,21 @@ fn ts_roll(uv: vec2<f32>, progress: f32, direction: i32) -> vec4<f32> {
 // 10-11: Sliding door (open/close)
 fn ts_sliding_door(uv: vec2<f32>, progress: f32, opening: bool) -> vec4<f32> {
     let center_distance = abs(uv.x - 0.5) * 2.0;
-    var threshold: f32;
 
     if opening {
-        threshold = progress;
+        // Open: B expands from center outward
+        if center_distance < progress {
+            return sample_with_fit(texture_b, sampler_b, uv, material.image_b_size, material.window_size);
+        } else {
+            return sample_with_fit(texture_a, sampler_a, uv, material.image_a_size, material.window_size);
+        }
     } else {
-        threshold = 1.0 - progress;
-    }
-
-    if center_distance < threshold {
-        return sample_with_fit(texture_b, sampler_b, uv, material.image_b_size, material.window_size);
-    } else {
-        return sample_with_fit(texture_a, sampler_a, uv, material.image_a_size, material.window_size);
+        // Close: B appears from edges inward
+        if center_distance > (1.0 - progress) {
+            return sample_with_fit(texture_b, sampler_b, uv, material.image_b_size, material.window_size);
+        } else {
+            return sample_with_fit(texture_a, sampler_a, uv, material.image_a_size, material.window_size);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The sliding door close transition (mode 11) had its A/B direction inverted — at `progress=0` it rendered 100% of the destination image instead of the source. Whenever random mode selected mode 11 (~5% of transitions), the destination flashed at full opacity for the first frame.

## Root Cause

The close branch used `center_distance < (1.0 - progress)` to select `texture_b`, which at `progress=0` evaluates to `center_distance < 1.0` — true for virtually every pixel. The fix changes the comparison to `center_distance > (1.0 - progress)`, so B correctly appears from the edges inward.

| progress | Before (bug) | After (fix) |
|----------|-------------|-------------|
| 0.0 | 100% B | 100% A |
| 0.5 | center B + edges A | edges B + center A |
| 1.0 | 100% A | 100% B |

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release`
- [x] Manual: mode 11 fixed, no flash with `random: true`

Closes #32
