### PR TITLE
docs: update stale thumbnail module note

### DIFF
--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -3,8 +3,8 @@
 //! Generates 256x256 thumbnails lazily (on demand) using async rayon workers.
 //! Uses an LRU cache with bounded memory to prevent unlimited growth.
 //!
-//! This module provides infrastructure for the future gallery view (issue #45).
-//! Currently unused but ready for integration.
+//! Used by the gallery flow to generate and cache thumbnails asynchronously for
+//! the overlay gallery view.
 
 use camino::{Utf8Path, Utf8PathBuf};
 use image::{GenericImageView, RgbaImage};


### PR DESCRIPTION
Closes #244

## Overview
Update src/thumbnail.rs module-level documentation to reflect current behavior.
The thumbnail manager is actively used in the gallery flow, not unused infrastructure.

## Changes
- Replaced stale comment claiming the module is "currently unused"
- Updated wording to describe asynchronous thumbnail generation/caching for overlay gallery view

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-features -- -D warnings
- [x] cargo test --all-features
- [x] cargo build --release
- [ ] Manual testing recommended
