### PR TITLE
fix: remove dead viewer.hot_reload config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ High-performance slideshow image viewer with custom [WGSL](https://www.w3.org/TR
 - **AmbientFit** — blurred background fill instead of black bars
 - **Screenshot & clipboard** — capture frame to PNG, copy image or path
 - **Drag & drop** — drop files/folders to load; Shift+drop to append
-- **Transparent & frameless windows**, hot-reload config, screen saver prevention (Windows)
+- **Transparent & frameless windows**, screen saver prevention (Windows)
 
 ## Quick Start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ This document describes the high-level architecture and key components of `sldsh
 | `image_loader.rs` | **Asset Management**. Asynchronous image loading using `rayon` (up to 4 concurrent tasks). `MipData` enum supports both SDR (`Rgba8`) and HDR (`Rgba16Float` via `half` crate) texture paths. Full mip chain generation. Supports EXR, PNG, JPEG, GIF, WebP, BMP, TGA, TIFF, ICO, HDR, AVIF, PNM, DDS. |
 | `thumbnail.rs` | **Thumbnails**. Generates and caches 256px thumbnails on background threads for the gallery view. Tracks stale textures via `drain_newly_cached()`. |
 | `overlay.rs` | **UI Layer**. Manages the `egui` context. Draws the filename bar, OSD, info overlay, help overlay (keyboard shortcut reference), settings panel (playback/transition/display/window controls), and gallery view (thumbnail grid with virtual scrolling). |
-| `config.rs` | **Configuration**. `serde::Deserialize` structs for parsing `.sldshow` TOML files. Supports hot-reload via file watching. |
+| `config.rs` | **Configuration**. `serde::Deserialize` structs for parsing `.sldshow` TOML files with defaults and validation. |
 | `timer.rs` | **Slideshow Timer**. State machine for auto-advancing slides with pause/resume. |
 | `clipboard.rs` | **System Integration**. Async image-to-clipboard copy using `arboard`. Re-reads image from disk to avoid GPU readback. |
 | `osc.rs` | **On-Screen Controller**. Floating auto-hide playback bar with scrub timeline, play/pause, next/prev, shuffle, and settings buttons. Uses Phosphor icon font. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,7 +122,6 @@ pub struct ViewerConfig {
     pub playback_mode: PlaybackMode,
     #[validate(range(min = 1.0, max = 240.0))]
     pub sequence_fps: f32,
-    pub hot_reload: bool,
     /// Maximum texture size [width, height] for GPU upload.
     /// Images larger than this are downscaled before GPU upload to reduce frame spikes.
     /// Lower values = faster uploads but lower quality. [1920, 1080] is a good balance.
@@ -147,7 +146,6 @@ impl Default for ViewerConfig {
             cache_extent: 5,
             playback_mode: PlaybackMode::Slideshow,
             sequence_fps: 24.0,
-            hot_reload: true,
             max_texture_size: [1920, 1080],
             filter_mode: FilterMode::Linear,
             fit_mode: FitMode::Fit,


### PR DESCRIPTION
Closes #237

## Overview
Remove the unused iewer.hot_reload configuration flag and align documentation with the actual runtime behavior.

## Changes
- Removed iewer.hot_reload from ViewerConfig and its default value.
- Updated README feature list to remove the hot-reload claim.
- Updated architecture docs to describe config.rs accurately.

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-features -- -D warnings
- [x] cargo test --all-features
- [x] cargo build --release
- [x] Manual testing recommended
