### PR TITLE
fix: avoid unconditional redraw requests on every window event

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1282,6 +1282,11 @@ impl ApplicationHandler for ApplicationState {
         // Forward event to egui first
         let egui_consumed = self.egui_overlay.handle_event(&self.window, &event);
 
+        // Track whether this event produced a visual state change that
+        // requires an immediate redraw. Animation-driven redraws are
+        // handled separately in `about_to_wait`.
+        let mut needs_redraw = egui_consumed;
+
         // Try input handler only if egui didn't consume the event
         let modifiers = self.modifiers;
         if !egui_consumed {
@@ -1289,6 +1294,9 @@ impl ApplicationHandler for ApplicationState {
             if should_exit {
                 event_loop.exit();
                 return;
+            }
+            if consumed {
+                needs_redraw = true;
             }
             if !consumed {
                 match event {
@@ -1331,14 +1339,19 @@ impl ApplicationHandler for ApplicationState {
                     #[cfg(not(windows))]
                     WindowEvent::DroppedFile(path) => {
                         self.drag_drop.queue_dropped_file(path);
+                        needs_redraw = true;
                     }
                     _ => {}
                 }
             }
         }
 
-        // Ensure the result of any window event is reflected on screen.
-        self.window.request_redraw();
+        // Only request a redraw when this event caused a visual state change.
+        // Idle events (cursor moves with no action, unbound keys, etc.) are
+        // skipped here; continuous animation is driven by `about_to_wait`.
+        if needs_redraw {
+            self.window.request_redraw();
+        }
     }
 
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {


### PR DESCRIPTION
Closes #236

## Overview
Removes the unconditional `request_redraw()` call at the end of `window_event()`, replacing it with a targeted `needs_redraw` flag that is only set when a window event actually produces a visual state change.

## Changes
- Introduce a `needs_redraw: bool` flag in `window_event()`, initialised to `egui_consumed`
- Set `needs_redraw = true` when the app input handler consumes an event (slide navigation, toggles, etc.)
- Set `needs_redraw = true` for `WindowEvent::DroppedFile` (file queued for processing)
- Keep the existing targeted `request_redraw()` inside the `Resized` branch
- Replace the old unconditional `self.window.request_redraw()` at the end of the handler with `if needs_redraw { self.window.request_redraw(); }`
- Continuous animation is unaffected — `about_to_wait()` already drives redraws whenever `is_animating()` is true

## Events no longer causing spurious redraws
- `CursorMoved` when the cursor is simply moving with no bound action
- Unbound `KeyboardInput` / `MouseInput` events
- `Focused`, `Moved`, `ModifiersChanged`, and other non-visual housekeeping events

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (9 tests)
- [x] `cargo build --release` succeeded
- [ ] Manual testing recommended: open `cargo run --release -- test.sldshow`, verify transitions, navigation, egui overlays, drag-and-drop, and resize all render correctly
