### PR TITLE
fix: replace unsafe transmute in EguiOverlay::render with safe forget_lifetime

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1188,7 +1188,7 @@ impl ApplicationState {
 
         // Render egui into a dedicated pass
         {
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            let render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Egui Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &view,
@@ -1204,7 +1204,7 @@ impl ApplicationState {
             });
 
             self.egui_overlay
-                .render(&mut render_pass, &clipped_primitives, &screen_descriptor);
+                .render(render_pass, &clipped_primitives, &screen_descriptor);
         }
 
         if self.screenshot_requested {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -644,19 +644,20 @@ impl EguiOverlay {
     /// Must call prepare_render() first to get clipped_primitives
     pub fn render<'rp>(
         &mut self,
-        render_pass: &mut wgpu::RenderPass<'rp>,
+        render_pass: wgpu::RenderPass<'rp>,
         clipped_primitives: &[egui::ClippedPrimitive],
         screen_descriptor: &egui_wgpu::ScreenDescriptor,
     ) {
-        // SAFETY: The egui_wgpu::Renderer::render signature uses RenderPass<'static>
-        // for API simplicity, but it doesn't actually require a 'static lifetime.
-        // The render pass is only used during this function call and doesn't escape.
-        // We transmute the lifetime to match the expected signature.
-        let render_pass_static: &mut wgpu::RenderPass<'static> =
-            unsafe { std::mem::transmute(render_pass) };
-
+        // `egui_wgpu::Renderer::render` requires `RenderPass<'static>`. We take
+        // the render pass by value and call the safe `forget_lifetime()` helper
+        // provided by wgpu to erase the lifetime. The only consequence of
+        // `forget_lifetime` is that any operation on the parent command encoder
+        // while this render pass is still alive produces a runtime error instead
+        // of a compile-time error; we do not touch the encoder here, so the
+        // invariant is trivially upheld.
+        let mut rp = render_pass.forget_lifetime();
         self.renderer
-            .render(render_pass_static, clipped_primitives, screen_descriptor);
+            .render(&mut rp, clipped_primitives, screen_descriptor);
     }
 
     /// Handle window resize


### PR DESCRIPTION
Closes #262

## Overview
Replaces the `unsafe { std::mem::transmute(...) }` block in `EguiOverlay::render` with the safe `wgpu::RenderPass::forget_lifetime()` helper, eliminating all `unsafe` code from the overlay render path.

## Root cause
`egui_wgpu::Renderer::render` requires a `&mut RenderPass<'static>`, but the render pass created from the command encoder carries a shorter lifetime. The previous code used a raw `transmute` to paper over this.

## Fix
`wgpu` provides `RenderPass::forget_lifetime(self) -> RenderPass<'static>`, a **safe** API that does the same lifetime erasure but with wgpu own runtime guardrails: touching the parent encoder while the render pass is alive produces a panic rather than undefined behaviour.

Because `forget_lifetime` takes the pass by value, `EguiOverlay::render` now accepts `wgpu::RenderPass<'rp>` by value instead of `&mut`. The single call-site in `app.rs` already drops the render pass immediately after the call, so the change is transparent.

## Changes
- `src/overlay.rs`: remove `unsafe` block; take `RenderPass` by value; call `forget_lifetime()`; add explanatory comment
- `src/app.rs`: pass render pass by value (drop `&mut`); drop now-redundant `mut` binding

## Testing
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo build --release` passes
- [ ] Manual visual test: `cargo run --release -- test.sldshow`
