### PR TITLE
test: add GPU shader tests for transition invariants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ egui-phosphor = "0.10"
 fast_image_resize = "5.1.4"
 half = "2"
 
+[[test]]
+name = "gpu_transition_invariants"
+path = "tests/gpu/transition_invariants.rs"
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [
     "Win32_System_Power",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+//! Public library surface for integration tests.
+//!
+//! Only the modules needed by `tests/` are re-exported here. The
+//! application entry point lives in `src/main.rs` and is compiled as a
+//! separate binary target.
+
+pub mod config;
+pub mod error;
+pub mod transition;

--- a/tests/gpu/helpers.rs
+++ b/tests/gpu/helpers.rs
@@ -1,0 +1,351 @@
+//! Shared GPU test infrastructure for offscreen transition shader tests.
+//!
+//! Key helpers:
+//! - [`try_setup_gpu`] — obtains a wgpu device/queue without a surface; returns
+//!   `None` if no adapter is available so tests can skip gracefully in CI.
+//! - [`create_solid_color_texture`] — uploads a 1×1 solid-colour RGBA8 texture.
+//! - [`render_transition`] — runs the transition pipeline to a 4×4 offscreen
+//!   `Rgba8Unorm` texture and returns the raw pixel bytes.
+//! - [`pixel_avg`] / [`assert_pixels_approx`] — comparison helpers with epsilon
+//!   tolerance for floating-point colour differences.
+
+use sldshow2::config::FilterMode;
+use sldshow2::transition::{TransitionPipeline, TransitionUniform};
+use wgpu::util::DeviceExt;
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/// Side length of the offscreen render target (pixels).
+pub const RENDER_SIZE: u32 = 4;
+
+/// Epsilon for per-channel byte comparisons (0–255 scale).
+pub const PIXEL_EPSILON: u8 = 8;
+
+// ---------------------------------------------------------------------------
+// GPU context
+// ---------------------------------------------------------------------------
+
+/// Minimal wgpu state needed by tests.
+pub struct GpuCtx {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+}
+
+/// Try to obtain a wgpu device+queue without a surface.
+///
+/// Returns `None` if no suitable adapter is available (e.g. headless CI);
+/// tests should call `return` (skip) in that case rather than panicking.
+pub fn try_setup_gpu() -> Option<GpuCtx> {
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        ..Default::default()
+    });
+
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::None,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .ok()?;
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("test-device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults(),
+        ..Default::default()
+    }))
+    .ok()?;
+
+    Some(GpuCtx { device, queue })
+}
+
+// ---------------------------------------------------------------------------
+// Texture helpers
+// ---------------------------------------------------------------------------
+
+/// Create a 1×1 solid-colour RGBA8Unorm texture on the GPU.
+///
+/// `rgba` is `[r, g, b, a]` in the range `0..=255`.
+pub fn create_solid_color_texture(ctx: &GpuCtx, rgba: [u8; 4]) -> wgpu::Texture {
+    ctx.device.create_texture_with_data(
+        &ctx.queue,
+        &wgpu::TextureDescriptor {
+            label: Some("solid-color-texture"),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        },
+        wgpu::util::TextureDataOrder::LayerMajor,
+        &rgba,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Offscreen rendering
+// ---------------------------------------------------------------------------
+
+/// The output texture format used for all offscreen renders.
+///
+/// `Rgba8Unorm` keeps readback arithmetic simple (byte values 0–255).
+pub const OFFSCREEN_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+/// Build the default-value [`TransitionUniform`] for tests.
+///
+/// Image size and window size are both set to `RENDER_SIZE × RENDER_SIZE`
+/// (square, 1:1 aspect ratio — avoids letterboxing).  All colour adjustments
+/// are set to identity values.
+pub fn default_uniform(mode: i32, blend: f32) -> TransitionUniform {
+    let sz = RENDER_SIZE as f32;
+    TransitionUniform {
+        blend,
+        mode,
+        aspect_ratio: [1.0, 1.0],
+        bg_color: [0.0, 0.0, 0.0, 1.0],
+        window_size: [sz, sz],
+        image_a_size: [1.0, 1.0],
+        image_b_size: [1.0, 1.0],
+        brightness: 0.0,
+        contrast: 1.0,
+        gamma: 1.0,
+        saturation: 1.0,
+        fit_mode: 0,       // Fit (letterbox)
+        ambient_blur: 5.0, // default, unused since fit_mode=0
+        zoom_scale: 1.0,
+        zoom_pan: [0.0, 0.0],
+        display_mode: 0, // SDR
+    }
+}
+
+/// Render one frame of the transition shader to a `RENDER_SIZE×RENDER_SIZE`
+/// offscreen texture and return the raw RGBA8 pixel bytes.
+///
+/// # Arguments
+/// * `ctx`     — GPU device+queue from [`try_setup_gpu`].
+/// * `tex_a`   — "from" texture (displayed at `blend = 0`).
+/// * `tex_b`   — "to" texture  (displayed at `blend = 1`).
+/// * `mode`    — transition mode index (0–19).
+/// * `blend`   — progress in `[0.0, 1.0]`.
+///
+/// Returns `RENDER_SIZE * RENDER_SIZE * 4` bytes (RGBA8, row-major).
+pub fn render_transition(
+    ctx: &GpuCtx,
+    tex_a: &wgpu::Texture,
+    tex_b: &wgpu::Texture,
+    mode: i32,
+    blend: f32,
+) -> Vec<u8> {
+    let GpuCtx { device, queue } = ctx;
+
+    // ── pipeline ────────────────────────────────────────────────────────────
+    let pipeline = TransitionPipeline::new(device, OFFSCREEN_FORMAT, FilterMode::Nearest);
+
+    // ── uniform buffer ───────────────────────────────────────────────────────
+    let uniform = default_uniform(mode, blend);
+    let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("test-uniform"),
+        contents: bytemuck::cast_slice(&[uniform]),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+    });
+
+    // ── texture views ────────────────────────────────────────────────────────
+    let view_a = tex_a.create_view(&wgpu::TextureViewDescriptor::default());
+    let view_b = tex_b.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let bind_group = pipeline.create_bind_group(device, &uniform_buf, &view_a, &view_b);
+
+    // ── offscreen render target ──────────────────────────────────────────────
+    let render_tex = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("offscreen-target"),
+        size: wgpu::Extent3d {
+            width: RENDER_SIZE,
+            height: RENDER_SIZE,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: OFFSCREEN_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let render_view = render_tex.create_view(&wgpu::TextureViewDescriptor::default());
+
+    // ── readback buffer ──────────────────────────────────────────────────────
+    // Row pitch must be a multiple of 256 (wgpu COPY_BYTES_PER_ROW_ALIGNMENT).
+    let bytes_per_pixel: u32 = 4; // Rgba8Unorm
+    let unpadded_row_bytes = RENDER_SIZE * bytes_per_pixel;
+    let padded_row_bytes = align_up(unpadded_row_bytes, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    let readback_size = (padded_row_bytes * RENDER_SIZE) as u64;
+
+    let readback_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: readback_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    // ── encode & submit ──────────────────────────────────────────────────────
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("test-encoder"),
+    });
+
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("test-pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &render_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        pass.set_pipeline(&pipeline.render_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1); // fullscreen triangle
+    }
+
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &render_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback_buf,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_row_bytes),
+                rows_per_image: Some(RENDER_SIZE),
+            },
+        },
+        wgpu::Extent3d {
+            width: RENDER_SIZE,
+            height: RENDER_SIZE,
+            depth_or_array_layers: 1,
+        },
+    );
+
+    queue.submit(std::iter::once(encoder.finish()));
+
+    // ── map_async readback ───────────────────────────────────────────────────
+    let slice = readback_buf.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        tx.send(result).expect("channel send failed");
+    });
+
+    // Poll until the GPU finishes.
+    device.poll(wgpu::PollType::Wait).expect("GPU poll failed");
+    rx.recv()
+        .expect("map_async channel closed")
+        .expect("map_async failed");
+
+    // Strip row padding so the caller gets exactly RENDER_SIZE * RENDER_SIZE * 4 bytes.
+    let mapped = slice.get_mapped_range();
+    let mut pixels = Vec::with_capacity((RENDER_SIZE * RENDER_SIZE * bytes_per_pixel) as usize);
+    for row in 0..RENDER_SIZE as usize {
+        let row_start = row * padded_row_bytes as usize;
+        let row_end = row_start + unpadded_row_bytes as usize;
+        pixels.extend_from_slice(&mapped[row_start..row_end]);
+    }
+    drop(mapped);
+    readback_buf.unmap();
+
+    pixels
+}
+
+// ---------------------------------------------------------------------------
+// Pixel analysis helpers
+// ---------------------------------------------------------------------------
+
+/// Average RGBA value across all pixels in a readback buffer.
+///
+/// Returns `[r_avg, g_avg, b_avg, a_avg]` as `f32` in `0.0..=255.0`.
+pub fn pixel_avg(pixels: &[u8]) -> [f32; 4] {
+    assert!(
+        pixels.len() % 4 == 0,
+        "pixel buffer length not a multiple of 4"
+    );
+    let count = (pixels.len() / 4) as f32;
+    let mut sum = [0.0f32; 4];
+    for chunk in pixels.chunks_exact(4) {
+        sum[0] += chunk[0] as f32;
+        sum[1] += chunk[1] as f32;
+        sum[2] += chunk[2] as f32;
+        sum[3] += chunk[3] as f32;
+    }
+    [
+        sum[0] / count,
+        sum[1] / count,
+        sum[2] / count,
+        sum[3] / count,
+    ]
+}
+
+/// Assert that the average pixel colour of `pixels` is approximately `expected`
+/// (per-channel, on a 0–255 scale) within `epsilon`.
+///
+/// On failure, the assertion message shows mode, blend, and actual vs. expected.
+pub fn assert_avg_approx(pixels: &[u8], expected: [f32; 4], epsilon: f32, label: &str) {
+    let avg = pixel_avg(pixels);
+    for (ch, (a, e)) in avg.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (a - e).abs() <= epsilon,
+            "{label}: channel {ch} avg={a:.1} expected≈{e:.1} (ε={epsilon})"
+        );
+    }
+}
+
+/// Assert that the average pixel colour is NOT approximately `excluded_color`
+/// (i.e. the image is not a solid `excluded_color`).
+///
+/// Used to verify the mid-blend invariant: at `blend = 0.5` the output must
+/// differ visibly from both texture_a and texture_b.
+pub fn assert_avg_not_approx(pixels: &[u8], excluded: [f32; 4], min_diff: f32, label: &str) {
+    let avg = pixel_avg(pixels);
+    let max_channel_diff = avg
+        .iter()
+        .zip(excluded.iter())
+        .map(|(a, e)| (a - e).abs())
+        .fold(0.0f32, f32::max);
+    assert!(
+        max_channel_diff >= min_diff,
+        "{label}: avg {avg:?} is too close to excluded colour {excluded:?} \
+         (max channel diff {max_channel_diff:.1} < required {min_diff})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+fn align_up(value: u32, alignment: u32) -> u32 {
+    (value + alignment - 1) & !(alignment - 1)
+}
+
+// Silence the dead_code lint for `TransitionUniform` fields — the struct is
+// constructed via field initialisation in `default_uniform`, which Rust
+// considers "used", but some fields might only be read by the GPU.
+#[allow(dead_code)]
+const _: () = {
+    // Compile-time size check: must match WGSL struct size (96 bytes).
+    // If this fails, the Rust repr(C) layout diverged from the shader.
+    const _SIZE_CHECK: [u8; 96] = [0u8; std::mem::size_of::<TransitionUniform>()];
+};

--- a/tests/gpu/transition_invariants.rs
+++ b/tests/gpu/transition_invariants.rs
@@ -1,0 +1,257 @@
+//! GPU integration tests for transition shader invariants.
+//!
+//! These tests render the transition WGSL shader to an offscreen texture using
+//! wgpu and verify three fundamental invariants that must hold for **every**
+//! transition mode (0–19):
+//!
+//! | `blend` value | Expected output |
+//! |:---:|:---|
+//! | `0.0` | All pixels ≈ **texture_a** colour (red) |
+//! | `1.0` | All pixels ≈ **texture_b** colour (blue) |
+//! | `0.5` | Average pixel ≠ red **and** ≠ blue (mid-blend visible) |
+//!
+//! The two source textures are 1×1 solid colours:
+//! - **texture_a** — red  `[255, 0, 0, 255]`
+//! - **texture_b** — blue `[0, 0, 255, 255]`
+//!
+//! # Skipping in headless CI
+//!
+//! If no GPU adapter is available (e.g. a GitHub Actions runner without a
+//! GPU), [`helpers::try_setup_gpu`] returns `None` and each test returns
+//! early — it is **not** counted as a failure.
+
+mod helpers;
+
+use helpers::{
+    PIXEL_EPSILON, RENDER_SIZE, assert_avg_approx, assert_avg_not_approx,
+    create_solid_color_texture, render_transition, try_setup_gpu,
+};
+
+// ── Solid-colour definitions (0-255 scale, as f32 for comparison) ──────────
+
+/// texture_a: solid red
+const RED: [u8; 4] = [255, 0, 0, 255];
+/// texture_b: solid blue
+const BLUE: [u8; 4] = [0, 0, 255, 255];
+
+/// Expected average colour when the output should be ≈ red (f32, 0–255).
+const RED_F: [f32; 4] = [255.0, 0.0, 0.0, 255.0];
+/// Expected average colour when the output should be ≈ blue (f32, 0–255).
+const BLUE_F: [f32; 4] = [0.0, 0.0, 255.0, 255.0];
+
+/// Minimum per-channel difference required for the "mid-blend" assertion.
+///
+/// At `blend = 0.5`, discrete transitions show ~half the pixels as red and
+/// ~half as blue, giving an average ≈ (128, 0, 128, 255).  The maximum
+/// channel difference from pure red is ≥ 100 (blue channel 0→128), and from
+/// pure blue is ≥ 100 (red channel 0→128).  A threshold of 50 is conservative
+/// enough to pass all modes while still catching regressions.
+const MID_BLEND_MIN_DIFF: f32 = 50.0;
+
+// ---------------------------------------------------------------------------
+// Helper: run all three invariant checks for one transition mode
+// ---------------------------------------------------------------------------
+
+fn check_mode_invariants(mode: i32) {
+    let Some(ctx) = try_setup_gpu() else {
+        eprintln!("No GPU adapter available — skipping GPU tests (mode {mode})");
+        return;
+    };
+
+    let tex_a = create_solid_color_texture(&ctx, RED);
+    let tex_b = create_solid_color_texture(&ctx, BLUE);
+
+    // ── Invariant 1: blend = 0.0 → output ≈ texture_a (red) ────────────────
+    {
+        let pixels = render_transition(&ctx, &tex_a, &tex_b, mode, 0.0);
+        assert_eq!(
+            pixels.len() as u32,
+            RENDER_SIZE * RENDER_SIZE * 4,
+            "mode {mode}: unexpected pixel buffer length at blend=0.0"
+        );
+        assert_avg_approx(
+            &pixels,
+            RED_F,
+            PIXEL_EPSILON as f32,
+            &format!("mode {mode} blend=0.0"),
+        );
+    }
+
+    // ── Invariant 2: blend = 1.0 → output ≈ texture_b (blue) ───────────────
+    {
+        let pixels = render_transition(&ctx, &tex_a, &tex_b, mode, 1.0);
+        assert_avg_approx(
+            &pixels,
+            BLUE_F,
+            PIXEL_EPSILON as f32,
+            &format!("mode {mode} blend=1.0"),
+        );
+    }
+
+    // ── Invariant 3: blend = 0.5 → output is in mid-blend state ─────────────
+    // The average must differ from both pure red and pure blue by at least
+    // MID_BLEND_MIN_DIFF in at least one channel.
+    {
+        let pixels = render_transition(&ctx, &tex_a, &tex_b, mode, 0.5);
+        assert_avg_not_approx(
+            &pixels,
+            RED_F,
+            MID_BLEND_MIN_DIFF,
+            &format!("mode {mode} blend=0.5 (not pure red)"),
+        );
+        assert_avg_not_approx(
+            &pixels,
+            BLUE_F,
+            MID_BLEND_MIN_DIFF,
+            &format!("mode {mode} blend=0.5 (not pure blue)"),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// One test per transition mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mode_00_crossfade() {
+    check_mode_invariants(0);
+}
+
+#[test]
+fn mode_01_smooth_crossfade() {
+    check_mode_invariants(1);
+}
+
+#[test]
+fn mode_02_roll_from_top() {
+    check_mode_invariants(2);
+}
+
+#[test]
+fn mode_03_roll_from_bottom() {
+    check_mode_invariants(3);
+}
+
+#[test]
+fn mode_04_roll_from_left() {
+    check_mode_invariants(4);
+}
+
+#[test]
+fn mode_05_roll_from_right() {
+    check_mode_invariants(5);
+}
+
+#[test]
+fn mode_06_roll_from_top_left() {
+    check_mode_invariants(6);
+}
+
+#[test]
+fn mode_07_roll_from_top_right() {
+    check_mode_invariants(7);
+}
+
+#[test]
+fn mode_08_roll_from_bottom_left() {
+    check_mode_invariants(8);
+}
+
+#[test]
+fn mode_09_roll_from_bottom_right() {
+    check_mode_invariants(9);
+}
+
+#[test]
+fn mode_10_sliding_door_open() {
+    check_mode_invariants(10);
+}
+
+#[test]
+fn mode_11_sliding_door_close() {
+    check_mode_invariants(11);
+}
+
+#[test]
+fn mode_12_blind_horizontal_a() {
+    check_mode_invariants(12);
+}
+
+#[test]
+fn mode_13_blind_horizontal_b() {
+    check_mode_invariants(13);
+}
+
+#[test]
+fn mode_14_blind_vertical_a() {
+    check_mode_invariants(14);
+}
+
+#[test]
+fn mode_15_blind_vertical_b() {
+    check_mode_invariants(15);
+}
+
+#[test]
+fn mode_16_box_expand() {
+    check_mode_invariants(16);
+}
+
+#[test]
+fn mode_17_box_contract() {
+    check_mode_invariants(17);
+}
+
+#[test]
+fn mode_18_random_squares() {
+    check_mode_invariants(18);
+}
+
+#[test]
+fn mode_19_angular_wipe() {
+    check_mode_invariants(19);
+}
+
+// ---------------------------------------------------------------------------
+// Sanity test: verify that the test setup itself works correctly
+// ---------------------------------------------------------------------------
+
+/// Confirms that the GPU helper infrastructure returns sensible pixel data
+/// independently of any particular transition mode.
+#[test]
+fn gpu_setup_sanity() {
+    let Some(ctx) = try_setup_gpu() else {
+        eprintln!("No GPU adapter available — skipping GPU tests");
+        return;
+    };
+
+    // A 4×4 red texture rendered with blend=0.0 must produce all-red pixels.
+    let red = create_solid_color_texture(&ctx, RED);
+    let blue = create_solid_color_texture(&ctx, BLUE);
+    let pixels = render_transition(&ctx, &red, &blue, 0, 0.0);
+
+    assert_eq!(
+        pixels.len() as u32,
+        RENDER_SIZE * RENDER_SIZE * 4,
+        "pixel buffer must be RENDER_SIZE² × 4 bytes"
+    );
+
+    // Every pixel must be approximately red.
+    for (i, chunk) in pixels.chunks_exact(4).enumerate() {
+        assert!(
+            (chunk[0] as i32 - 255).abs() <= PIXEL_EPSILON as i32,
+            "pixel {i}: R channel {}, expected ≈255",
+            chunk[0]
+        );
+        assert!(
+            chunk[1] <= PIXEL_EPSILON,
+            "pixel {i}: G channel {}, expected ≈0",
+            chunk[1]
+        );
+        assert!(
+            chunk[2] <= PIXEL_EPSILON,
+            "pixel {i}: B channel {}, expected ≈0",
+            chunk[2]
+        );
+    }
+}


### PR DESCRIPTION
Closes #235

## Overview
Adds a GPU integration test harness in `tests/gpu/` that renders the transition WGSL shader offscreen and verifies three fundamental invariants for all 20 transition modes.

## Changes

### New files
- **`src/lib.rs`** — Minimal library target re-exporting `transition`, `config`, and `error` modules so integration tests can import `TransitionPipeline` / `TransitionUniform` without duplicating the struct layout.
- **`tests/gpu/helpers.rs`** — Shared GPU test infrastructure:
  - `try_setup_gpu()` — obtains a surfaceless `Device`+`Queue`; returns `None` on headless CI (graceful skip, not failure)
  - `create_solid_color_texture()` — uploads a 1×1 solid-colour `Rgba8Unorm` texture
  - `render_transition()` — runs the `TransitionPipeline` to a 4×4 offscreen texture, reads back via `map_async` + `PollType::Wait`, strips row padding
  - `pixel_avg()` / `assert_avg_approx()` / `assert_avg_not_approx()` — per-channel comparison helpers with epsilon tolerance
- **`tests/gpu/transition_invariants.rs`** — 21 `#[test]` functions: one per transition mode (0–19) plus a `gpu_setup_sanity` check. Each mode is exercised at `blend=0.0`, `blend=1.0`, and `blend=0.5`.

### Modified files
- **`Cargo.toml`** — Adds a `[[test]]` entry pointing to `tests/gpu/transition_invariants.rs`; no new runtime dependencies required (wgpu, pollster, bytemuck already in `[dependencies]`).

## Invariants tested

| `blend` | Invariant |
|:---:|:---|
| `0.0` | Average pixel ≈ texture_a (solid red `[255,0,0,255]`) |
| `1.0` | Average pixel ≈ texture_b (solid blue `[0,0,255,255]`) |
| `0.5` | Average differs from **both** red and blue by ≥ 50 units |

The `blend=0.5` check works for both blending modes (crossfade → (128,0,128)) and discrete wipe modes (half pixels red + half blue → same average).

## Testing
- [x] `cargo fmt --all -- --check` ✅
- [x] `cargo clippy --all-features -- -D warnings` ✅
- [x] `cargo test --all-features` ✅ — 21 new GPU tests + 12 pre-existing tests all pass
- [x] `cargo build --release` ✅
