### PR TITLE
fix: guard against NaN in transition blend factor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1081,8 +1081,12 @@ impl ApplicationState {
         // Prepare BindGroup and Uniforms
         // Determine which textures to use
         let (tex_a_idx, tex_b_idx, blend, mode) = if let Some(ref t) = self.transition {
-            let progress = t.start_time.elapsed().as_secs_f32() / t.duration.as_secs_f32();
-            (t.from_index, t.to_index, progress.min(1.0), t.mode)
+            let ratio = t.start_time.elapsed().as_secs_f32() / t.duration.as_secs_f32();
+            // Guard against NaN: a near-zero duration can produce a zero-length
+            // Duration after f32 → Duration conversion, causing 0/0 = NaN.
+            // `.min(1.0)` catches infinity but not NaN, so we handle it explicitly.
+            let progress = if ratio.is_nan() { 1.0 } else { ratio.min(1.0) };
+            (t.from_index, t.to_index, progress, t.mode)
         } else if let Some(idx) = self.current_texture_index {
             (idx, idx, 0.0, 0)
         } else {


### PR DESCRIPTION
Closes #257

## Overview
Guards the transition blend factor calculation against NaN, which can occur when a near-zero 32 duration value loses precision during Duration::from_secs_f32 conversion, producing a zero-length Duration and a  .0 / 0.0 division.

## Changes
- src/app.rs ender(): split the ratio calculation from the clamp, add an explicit is_nan() check — if NaN is detected the progress is treated as 1.0 (transition complete), the safest fallback

## Root cause
Duration::from_secs_f32(x) saturates to zero for very small x, so 	.duration.as_secs_f32() can return  .0. Dividing elapsed  .0 / 0.0 produces NaN. The prior .min(1.0) guard handles +infinity (finite comparison) but NaN.min(1.0) propagates NaN, corrupting the shader uniform.

## Testing
- [x] cargo fmt --all -- --check passed
- [x] cargo clippy --all-features -- -D warnings passed
- [x] cargo build --release passed
- [ ] Manual test: launch the app with a slideshow that has extremely short transition durations and verify no visual glitches occur
