### PR TITLE
refactor: consolidate fast_resize_exact and fast_resize into a single shared function

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -466,7 +466,7 @@ fn linear_to_srgb(c: f32) -> f32 {
 }
 
 // Helper to perform fast resizing using fast_image_resize
-fn fast_resize(
+pub(crate) fn fast_resize(
     src_img: fast_image_resize::images::Image,
     dst_width: u32,
     dst_height: u32,

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -14,7 +14,7 @@ use std::collections::{HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::sync::mpsc::{Receiver, Sender, channel};
 
-use crate::image_loader::apply_exif_rotation;
+use crate::image_loader::{apply_exif_rotation, fast_resize};
 
 /// Fixed thumbnail dimensions (square, aspect-preserving)
 const THUMBNAIL_SIZE: u32 = 256;
@@ -178,32 +178,6 @@ impl ThumbnailManager {
     }
 }
 
-// Helper to perform fast resizing using fast_image_resize
-fn fast_resize_exact(
-    src_img: fast_image_resize::images::Image,
-    dst_width: u32,
-    dst_height: u32,
-    filter: fast_image_resize::FilterType,
-) -> anyhow::Result<RgbaImage> {
-    let mut dst_img = fast_image_resize::images::Image::new(
-        dst_width,
-        dst_height,
-        fast_image_resize::PixelType::U8x4,
-    );
-
-    let mut resizer = fast_image_resize::Resizer::new();
-    let resize_opts = fast_image_resize::ResizeOptions::new()
-        .resize_alg(fast_image_resize::ResizeAlg::Convolution(filter));
-
-    resizer
-        .resize(&src_img, &mut dst_img, &resize_opts)
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-    let buffer = dst_img.into_vec();
-    RgbaImage::from_raw(dst_width, dst_height, buffer)
-        .ok_or_else(|| anyhow::anyhow!("from_raw failed"))
-}
-
 /// Generate a 256x256 thumbnail from an image file.
 /// Preserves aspect ratio with letterboxing.
 #[allow(dead_code)]
@@ -230,7 +204,7 @@ fn generate_thumbnail(path: &Utf8Path) -> anyhow::Result<RgbaImage> {
     )
     .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-    let resized = fast_resize_exact(
+    let resized = fast_resize(
         src_image,
         new_w,
         new_h,


### PR DESCRIPTION
Closes #256.

## Overview
Eliminates the duplicate `fast_resize_exact()` helper in `thumbnail.rs` by promoting `fast_resize()` in `image_loader.rs` to `pub(crate)` and reusing it directly.

## Changes
- `src/image_loader.rs`: changed `fn fast_resize` to `pub(crate) fn fast_resize`
- `src/thumbnail.rs`: removed `fast_resize_exact` (26 lines), imported `image_loader::fast_resize`, updated `generate_thumbnail()` call site

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (9/9 tests)
- [ ] Manual testing recommended
