### PR TITLE
fix: add bounds check before paths[current_index] in CopyImageToClipboard

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -470,20 +470,27 @@ impl ApplicationState {
                 } else if self.clipboard_receiver.is_some() {
                     self.show_osd("Copying...".to_string());
                 } else {
-                    let current_path =
-                        self.texture_manager.paths[self.texture_manager.current_index].clone();
+                    let current_path = self
+                        .texture_manager
+                        .paths
+                        .get(self.texture_manager.current_index)
+                        .cloned();
 
-                    let (tx, rx) = std::sync::mpsc::channel();
-                    self.clipboard_receiver = Some(rx);
-                    self.show_osd("Copying to Clipboard...".to_string());
+                    if let Some(current_path) = current_path {
+                        let (tx, rx) = std::sync::mpsc::channel();
+                        self.clipboard_receiver = Some(rx);
+                        self.show_osd("Copying to Clipboard...".to_string());
 
-                    std::thread::spawn(move || {
-                        let res = match clipboard::copy_image_to_clipboard(&current_path) {
-                            Ok(_) => Ok(()),
-                            Err(e) => Err(format!("{}", e)),
-                        };
-                        let _ = tx.send(res);
-                    });
+                        std::thread::spawn(move || {
+                            let res = match clipboard::copy_image_to_clipboard(&current_path) {
+                                Ok(_) => Ok(()),
+                                Err(e) => Err(format!("{}", e)),
+                            };
+                            let _ = tx.send(res);
+                        });
+                    } else {
+                        self.show_osd("No Image Loaded".to_string());
+                    }
                 }
             }
             InputAction::ToggleHelpOverlay => {


### PR DESCRIPTION
Closes #263

## Overview
Replaces the direct `paths[current_index]` indexing in the `CopyImageToClipboard` handler with a safe `.get(current_index)` call, handling the `None` case with user-visible OSD feedback instead of a panic.

## Changes
- `src/app.rs`: Replace `self.texture_manager.paths[self.texture_manager.current_index]` with `.get(current_index).cloned()`, and handle `None` by calling `self.show_osd("No Image Loaded")`.

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (9/9 tests)
- [x] `cargo build --release` succeeded
- [ ] Manual testing recommended
