### PR TITLE
refactor: remove apply_exif_rotation duplication — reuse apply_orientation helpers

### DIFF
--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -599,7 +599,9 @@ fn mip_level_count(width: u32, height: u32) -> u32 {
 }
 
 /// Read the EXIF orientation tag from a reader without consuming the whole stream.
-fn read_exif_orientation<R: std::io::BufRead + std::io::Seek>(reader: &mut R) -> Option<u32> {
+pub(crate) fn read_exif_orientation<R: std::io::BufRead + std::io::Seek>(
+    reader: &mut R,
+) -> Option<u32> {
     exif::Reader::new()
         .read_from_container(reader)
         .ok()?
@@ -609,7 +611,10 @@ fn read_exif_orientation<R: std::io::BufRead + std::io::Seek>(reader: &mut R) ->
 }
 
 /// Apply a raw EXIF orientation value to an image.
-fn apply_orientation(img: image::DynamicImage, orientation: Option<u32>) -> image::DynamicImage {
+pub(crate) fn apply_orientation(
+    img: image::DynamicImage,
+    orientation: Option<u32>,
+) -> image::DynamicImage {
     match orientation {
         Some(2) => img.fliph(),
         Some(3) => img.rotate180(),
@@ -619,37 +624,6 @@ fn apply_orientation(img: image::DynamicImage, orientation: Option<u32>) -> imag
         Some(7) => img.rotate270().fliph(),
         Some(8) => img.rotate270(),
         _ => img,
-    }
-}
-
-pub fn apply_exif_rotation(img: image::DynamicImage, path: &Utf8Path) -> image::DynamicImage {
-    use std::fs::File;
-    use std::io::BufReader;
-
-    let file = match File::open(path.as_std_path()) {
-        Ok(f) => f,
-        Err(_) => return img,
-    };
-
-    let mut reader = BufReader::new(&file);
-    let exifreader = exif::Reader::new();
-    let exif = match exifreader.read_from_container(&mut reader) {
-        Ok(exif) => exif,
-        Err(_) => return img,
-    };
-
-    match exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY) {
-        Some(field) => match field.value.get_uint(0) {
-            Some(2) => img.fliph(),
-            Some(3) => img.rotate180(),
-            Some(4) => img.flipv(),
-            Some(5) => img.rotate90().fliph(),
-            Some(6) => img.rotate90(),
-            Some(7) => img.rotate270().fliph(),
-            Some(8) => img.rotate270(),
-            _ => img,
-        },
-        None => img,
     }
 }
 

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -14,7 +14,7 @@ use std::collections::{HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::sync::mpsc::{Receiver, Sender, channel};
 
-use crate::image_loader::apply_exif_rotation;
+use crate::image_loader::{apply_orientation, read_exif_orientation};
 
 /// Fixed thumbnail dimensions (square, aspect-preserving)
 const THUMBNAIL_SIZE: u32 = 256;
@@ -212,7 +212,11 @@ fn generate_thumbnail(path: &Utf8Path) -> anyhow::Result<RgbaImage> {
         .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
 
     // Apply EXIF rotation (shared with image_loader)
-    let img = apply_exif_rotation(img, path);
+    let orientation = std::fs::File::open(path.as_std_path())
+        .ok()
+        .map(|f| read_exif_orientation(&mut std::io::BufReader::new(f)))
+        .unwrap_or(None);
+    let img = apply_orientation(img, orientation);
 
     // Resize to fit within 256x256, preserving aspect ratio
     let (orig_w, orig_h) = img.dimensions();


### PR DESCRIPTION
Closes #250

## Overview
Removes the duplicate pply_exif_rotation() function from image_loader.rs by promoting the existing ead_exif_orientation() and pply_orientation() helpers to pub(crate) and updating 	humbnail.rs to call them directly.

## Changes
- src/image_loader.rs: promoted ead_exif_orientation() and pply_orientation() to pub(crate), removed the duplicate pply_exif_rotation() function
- src/thumbnail.rs: updated generate_thumbnail() to call ead_exif_orientation() + pply_orientation() instead of the removed pply_exif_rotation()

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (9/9 tests)
