### PR TITLE
refactor: replace raw i32 TransitionConfig::mode with TransitionMode newtype

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use winit::{
 };
 
 use crate::clipboard;
-use crate::config::{self, Config};
+use crate::config::{self, Config, TransitionMode};
 use crate::drag_drop::DragDropHandler;
 use crate::image_loader::{self, TextureManager};
 use crate::input::{InputAction, InputContext, InputHandler};
@@ -90,7 +90,7 @@ pub struct ApplicationState {
 struct ActiveTransition {
     start_time: Instant,
     duration: Duration,
-    mode: i32,
+    mode: TransitionMode,
     from_index: usize,
     to_index: usize,
 }
@@ -1084,10 +1084,10 @@ impl ApplicationState {
             let progress = t.start_time.elapsed().as_secs_f32() / t.duration.as_secs_f32();
             (t.from_index, t.to_index, progress.min(1.0), t.mode)
         } else if let Some(idx) = self.current_texture_index {
-            (idx, idx, 0.0, 0)
+            (idx, idx, 0.0, TransitionMode::default())
         } else {
             // No images uploaded yet
-            (0, 0, 0.0, 0)
+            (0, 0, 0.0, TransitionMode::default())
         };
 
         // If textures are not loaded yet, we can't create bind group.
@@ -1109,7 +1109,7 @@ impl ApplicationState {
             // Update Uniforms
             let uniform = TransitionUniform {
                 blend,
-                mode,
+                mode: mode.into(),
                 aspect_ratio: [1.0, 1.0],
                 bg_color: self.config.bg_color_f32(),
                 window_size: [self.size.width as f32, self.size.height as f32],

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{Result, SldshowError};
 use camino::{Utf8Path, Utf8PathBuf};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use validator::Validate;
 
 /// Texture filtering mode
@@ -154,6 +154,57 @@ impl Default for ViewerConfig {
     }
 }
 
+/// A validated transition mode index in the range `0..=19`.
+///
+/// Enforces the range invariant at construction time via [`TryFrom<i32>`].
+/// Serializes and deserializes as a plain integer for TOML compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TransitionMode(i32);
+
+impl TransitionMode {
+    /// The minimum valid mode index.
+    pub const MIN: i32 = 0;
+    /// The maximum valid mode index.
+    pub const MAX: i32 = 19;
+
+    /// Returns the inner `i32` value.
+    #[inline]
+    pub fn value(self) -> i32 {
+        self.0
+    }
+}
+
+impl TryFrom<i32> for TransitionMode {
+    type Error = SldshowError;
+
+    fn try_from(value: i32) -> std::result::Result<Self, Self::Error> {
+        if (Self::MIN..=Self::MAX).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(SldshowError::InvalidTransitionMode(value))
+        }
+    }
+}
+
+impl From<TransitionMode> for i32 {
+    fn from(m: TransitionMode) -> i32 {
+        m.0
+    }
+}
+
+impl Serialize for TransitionMode {
+    fn serialize<S: Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for TransitionMode {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        let value = i32::deserialize(d)?;
+        TransitionMode::try_from(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Transition configuration
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(default)]
@@ -161,8 +212,7 @@ pub struct TransitionConfig {
     #[validate(range(min = 0.0, max = 10.0))]
     pub time: f32,
     pub random: bool,
-    #[validate(range(min = 0, max = 19))]
-    pub mode: i32,
+    pub mode: TransitionMode,
 }
 
 impl Default for TransitionConfig {
@@ -170,7 +220,7 @@ impl Default for TransitionConfig {
         Self {
             time: 0.5,
             random: true,
-            mode: 0,
+            mode: TransitionMode::default(),
         }
     }
 }
@@ -300,6 +350,46 @@ mod tests {
 
         assert_eq!(config.window.width, deserialized.window.width);
         assert_eq!(config.viewer.timer, deserialized.viewer.timer);
+    }
+
+    #[test]
+    fn test_transition_mode_valid_range() {
+        assert!(TransitionMode::try_from(0).is_ok());
+        assert!(TransitionMode::try_from(19).is_ok());
+        assert!(TransitionMode::try_from(10).is_ok());
+    }
+
+    #[test]
+    fn test_transition_mode_invalid_range() {
+        assert!(TransitionMode::try_from(-1).is_err());
+        assert!(TransitionMode::try_from(20).is_err());
+        assert!(TransitionMode::try_from(100).is_err());
+    }
+
+    #[test]
+    fn test_transition_mode_roundtrip() {
+        let m = TransitionMode::try_from(7).unwrap();
+        assert_eq!(i32::from(m), 7);
+        assert_eq!(m.value(), 7);
+    }
+
+    #[test]
+    fn test_transition_mode_serde() {
+        // Test round-trip through TransitionConfig (TOML requires a table at root)
+        let config = TransitionConfig {
+            mode: TransitionMode::try_from(5).unwrap(),
+            ..TransitionConfig::default()
+        };
+        let serialized = toml::to_string(&config).unwrap();
+        let deserialized: TransitionConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(config.mode, deserialized.mode);
+    }
+
+    #[test]
+    fn test_transition_mode_serde_invalid() {
+        let result: std::result::Result<TransitionConfig, _> =
+            toml::from_str("mode = 99\ntime = 0.5\nrandom = false");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ pub enum SldshowError {
 
     #[error("Image error: {0}")]
     ImageError(#[from] image::ImageError),
+
+    #[error("Invalid transition mode {0}: must be in range 0..=19")]
+    InvalidTransitionMode(i32),
 }
 
 pub type Result<T> = std::result::Result<T, SldshowError>;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -8,7 +8,7 @@ use wgpu::{Device, Queue, TextureFormat};
 use winit::event::WindowEvent;
 use winit::window::Window;
 
-use crate::config::{Config, FitMode};
+use crate::config::{Config, FitMode, TransitionMode};
 use crate::osc::{Osc, OscAction};
 use crate::thumbnail::ThumbnailManager;
 use std::collections::HashMap;
@@ -25,7 +25,7 @@ pub enum OverlayAction {
     ToggleScanSubfolders(bool),
     SetTransitionTime(f32),
     ToggleRandomTransition(bool),
-    SetTransitionMode(i32),
+    SetTransitionMode(TransitionMode),
     SetFitMode(FitMode),
     SetAmbientBlur(f32),
     ToggleAlwaysOnTop(bool),
@@ -513,12 +513,13 @@ impl EguiOverlay {
                     if !config.transition.random {
                         ui.horizontal(|ui| {
                             ui.label("Transition Mode:");
-                            if ui
-                                .add(egui::Slider::new(&mut config.transition.mode, 0..=19))
-                                .changed()
-                            {
-                                action =
-                                    Some(OverlayAction::SetTransitionMode(config.transition.mode));
+                            let mut mode_val: i32 = config.transition.mode.into();
+                            if ui.add(egui::Slider::new(&mut mode_val, 0..=19)).changed() {
+                                // Value comes from a bounded slider so try_from always succeeds.
+                                if let Ok(m) = TransitionMode::try_from(mode_val) {
+                                    config.transition.mode = m;
+                                    action = Some(OverlayAction::SetTransitionMode(m));
+                                }
                             }
                         });
                     }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -1,6 +1,6 @@
 //! WGPU render pipeline for image transitions with 20 WGSL shader effects.
 
-use crate::config::FilterMode;
+use crate::config::{FilterMode, TransitionMode};
 use bytemuck::{Pod, Zeroable};
 use std::borrow::Cow;
 
@@ -192,9 +192,11 @@ impl TransitionPipeline {
     }
 
     /// Pick a random transition mode from available effects
-    pub fn random_mode() -> i32 {
+    pub fn random_mode() -> TransitionMode {
         use rand::Rng;
         let mut rng = rand::rng();
-        rng.random_range(0..TRANSITION_MODE_COUNT)
+        // SAFETY: TRANSITION_MODE_COUNT is 20, so range is 0..20 i.e. 0..=19 which is valid
+        TransitionMode::try_from(rng.random_range(0..TRANSITION_MODE_COUNT))
+            .expect("random_range(0..20) always produces a valid TransitionMode")
     }
 }


### PR DESCRIPTION
Closes #260

## Overview
Replaces the raw `i32` field `TransitionConfig::mode` with a `TransitionMode` newtype that enforces the `0..=19` invariant at construction time, eliminating the post-deserialisation `#[validate(range)]` check.

## Changes
- **`src/config.rs`** — add `TransitionMode(i32)` newtype with:
  - `TryFrom<i32>` that rejects values outside `0..=19`
  - `From<TransitionMode> for i32` for GPU uniform conversion
  - Manual `Serialize`/`Deserialize` (round-trips as a plain integer for TOML compatibility)
  - `TransitionConfig::mode` type changed from `i32` to `TransitionMode`
  - Unit tests: valid range, invalid range, value round-trip, serde round-trip, serde rejection
- **`src/error.rs`** — add `SldshowError::InvalidTransitionMode(i32)` variant (used by `TryFrom`)
- **`src/transition.rs`** — `TransitionPipeline::random_mode()` return type changed to `TransitionMode`
- **`src/app.rs`** — `ActiveTransition::mode` field changed to `TransitionMode`; GPU uniform call site uses `.into()` to extract the `i32`; fallback arms use `TransitionMode::default()`
- **`src/overlay.rs`** — `OverlayAction::SetTransitionMode` payload changed to `TransitionMode`; slider uses a local `i32` temp variable and re-wraps via `TryFrom`

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (14/14)
- [x] `cargo build --release` succeeded
- [ ] Manual testing recommended: launch the app, open settings overlay, drag the Transition Mode slider, verify no crashes and mode changes correctly
