### PR TITLE
feat: improve Linux file-reveal behavior for Open in Explorer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -752,7 +752,26 @@ impl ApplicationState {
         }
         #[cfg(all(unix, not(target_os = "macos")))]
         {
+            // Best-effort reveal/select: try common file managers that support
+            // selecting a specific file, then fall back to opening the directory.
+            //
+            // • nautilus --select <file>  — GNOME Files
+            // • dolphin --select <file>   — KDE Dolphin
+            // • thunar <dir>              — XFCE Thunar (no select flag)
+            // • xdg-open <dir>            — universal fallback
             let dir = path.parent().unwrap_or(path);
+
+            if try_spawn_file_manager("nautilus", &["--select"], path) {
+                return Ok(());
+            }
+            if try_spawn_file_manager("dolphin", &["--select"], path) {
+                return Ok(());
+            }
+            if try_spawn_file_manager("thunar", &[], dir) {
+                return Ok(());
+            }
+
+            // Universal fallback: open the parent directory.
             std::process::Command::new("xdg-open").arg(dir).spawn()?;
         }
         Ok(())
@@ -1255,6 +1274,30 @@ impl ApplicationState {
             || self.texture_manager.is_loading()
             // Cursor visible — update() must run to auto-hide it
             || self.input_handler.cursor_visible
+    }
+}
+
+/// Attempt to launch `cmd` with optional `extra_args` followed by `target`.
+/// Returns `true` when the process was spawned successfully (binary found),
+/// `false` when the binary is not available so the caller can try the next
+/// option.  Only compiled on Linux / non-macOS Unix platforms.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn try_spawn_file_manager(cmd: &str, extra_args: &[&str], target: &std::path::Path) -> bool {
+    let mut command = std::process::Command::new(cmd);
+    for arg in extra_args {
+        command.arg(arg);
+    }
+    command.arg(target);
+    match command.spawn() {
+        Ok(_) => {
+            info!("Opened '{}' for file-reveal", cmd);
+            true
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(e) => {
+            warn!("'{}' failed to spawn: {}", cmd, e);
+            false
+        }
     }
 }
 


### PR DESCRIPTION
Closes #241

## Overview
Improves the Linux "Open in Explorer" behavior (`open_explorer`) by adding best-effort reveal/select support for common file managers, with graceful fallback to the existing `xdg-open <dir>` behavior.

## Changes
- Added `try_spawn_file_manager` helper (Linux-only via `#[cfg(all(unix, not(target_os = "macos")))]`) that probes a file manager binary and returns `false` if it is not installed
- Updated the Linux branch of `spawn_explorer` to try, in order:
  1. `nautilus --select <file>` — GNOME Files (reveals and selects the file)
  2. `dolphin --select <file>` — KDE Dolphin (reveals and selects the file)
  3. `thunar <dir>` — XFCE Thunar (opens the directory; no select flag)
  4. `xdg-open <dir>` — universal fallback (original behavior)
- Each candidate is tried in turn; if the binary is not found (`NotFound`), the next one is attempted
- All inline code comments explain the behavior for maintainability
- Windows and macOS behavior are completely unchanged

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo build --release` passed
- [ ] Manual testing on Linux recommended (requires a GNOME/KDE/XFCE environment)

### Manual test command
```bash
cargo run --release -- test.sldshow
# Press E (or configured key) to trigger Open in Explorer
# Verify the correct file manager opens with the file selected
```
