### PR TITLE
refactor: remove dead code suppressions -- unused Osc methods and ThumbnailManager blanket allow

### DIFF
--- a/src/osc.rs
+++ b/src/osc.rs
@@ -245,23 +245,4 @@ impl Osc {
 
         None
     }
-
-    /// Check if OSC is currently visible
-    #[allow(dead_code)]
-    pub fn is_visible(&self) -> bool {
-        self.visible
-    }
-
-    /// Force OSC to show (e.g., on window focus)
-    #[allow(dead_code)]
-    pub fn show(&mut self) {
-        self.visible = true;
-        self.last_interaction = Instant::now();
-    }
-
-    /// Force OSC to hide
-    #[allow(dead_code)]
-    pub fn hide(&mut self) {
-        self.visible = false;
-    }
 }

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -20,10 +20,8 @@ use crate::image_loader::apply_exif_rotation;
 const THUMBNAIL_SIZE: u32 = 256;
 
 /// Maximum number of concurrent thumbnail generation tasks
-#[allow(dead_code)]
 const MAX_CONCURRENT_GENERATION: usize = 4;
 
-#[allow(dead_code)]
 pub struct ThumbnailManager {
     /// LRU cache: index → thumbnail image (O(1) access and eviction)
     cache: LruCache<usize, RgbaImage>,
@@ -41,7 +39,6 @@ pub struct ThumbnailManager {
     newly_cached: Vec<usize>,
 }
 
-#[allow(dead_code)]
 impl ThumbnailManager {
     /// Create a new thumbnail manager with bounded cache size.
     pub fn new(max_cache_size: usize) -> Self {
@@ -135,6 +132,9 @@ impl ThumbnailManager {
     }
 
     /// Clear all cached thumbnails and cancel pending tasks.
+    // Not currently called from app code, but retained as a complete cache-management API
+    // that will be needed when full slideshow reload support is added.
+    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.cache.clear();
         self.loading_tasks.clear();
@@ -163,11 +163,15 @@ impl ThumbnailManager {
     }
 
     /// Returns the number of cached thumbnails.
+    // Used in unit tests to assert cache state; not called from app code.
+    #[allow(dead_code)]
     pub fn cache_size(&self) -> usize {
         self.cache.len()
     }
 
     /// Returns the number of thumbnails currently being generated.
+    // Used in unit tests to assert loading-task state; not called from app code.
+    #[allow(dead_code)]
     pub fn pending_count(&self) -> usize {
         self.loading_tasks.len()
     }
@@ -206,7 +210,6 @@ fn fast_resize_exact(
 
 /// Generate a 256x256 thumbnail from an image file.
 /// Preserves aspect ratio with letterboxing.
-#[allow(dead_code)]
 fn generate_thumbnail(path: &Utf8Path) -> anyhow::Result<RgbaImage> {
     let img = image::open(path.as_std_path())
         .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;


### PR DESCRIPTION
Closes #251

## Overview

Removes two unrelated `#[allow(dead_code)]` suppressions that were masking genuinely unused code in `osc.rs` and `thumbnail.rs`.

## Changes

### `src/osc.rs`
- Deleted `Osc::is_visible()`, `Osc::show()`, and `Osc::hide()` - three public methods never called anywhere in the codebase. Each carried its own `#[allow(dead_code)]`; removing the methods eliminates the suppressions entirely.

### `src/thumbnail.rs`
- Removed the blanket `#[allow(dead_code)]` on the `ThumbnailManager` struct and its `impl` block.
- Removed the now-unnecessary `#[allow(dead_code)]` from `MAX_CONCURRENT_GENERATION` (used in `request_thumbnail` and `update`) and `generate_thumbnail` (called by `spawn_generation`) - both are actively used.
- Added individual, justified `#[allow(dead_code)]` to the three items that remain unused by app code today:
  - `clear()` - retained as a complete cache-management API for future slideshow-reload support.
  - `cache_size()` / `pending_count()` - used exclusively by unit tests to assert internal state.

## Testing
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (9/9 tests)
- [x] `cargo build --release` passes
