### PR TITLE
fix: differentiate ts_blind open/close directions for modes 12-15

### DIFF
--- a/assets/shaders/transition.wgsl
+++ b/assets/shaders/transition.wgsl
@@ -214,20 +214,28 @@ fn ts_sliding_door(uv: vec2<f32>, progress: f32, opening: bool) -> vec4<f32> {
     }
 }
 
-// 12-15: Blind effects (horizontal/vertical)
+// 12-15: Blind effects (horizontal/vertical, open outward/close inward)
 fn ts_blind(uv: vec2<f32>, progress: f32, direction: i32) -> vec4<f32> {
     let slices = 10.0;
     var slice_progress: f32;
+    var open_outward: bool;
 
     if direction == 0 || direction == 1 { // horizontal
-        let slice_idx = floor(uv.y * slices);
         slice_progress = fract(uv.y * slices);
+        open_outward = direction == 0;
     } else { // vertical
-        let slice_idx = floor(uv.x * slices);
         slice_progress = fract(uv.x * slices);
+        open_outward = direction == 2;
     }
 
-    if slice_progress < progress {
+    var show_new: bool;
+    if open_outward {
+        show_new = slice_progress < progress;
+    } else {
+        show_new = slice_progress > (1.0 - progress);
+    }
+
+    if show_new {
         return sample_with_fit(texture_b, sampler_b, uv, material.image_b_size, material.window_size);
     } else {
         return sample_with_fit(texture_a, sampler_a, uv, material.image_a_size, material.window_size);

--- a/src/input.rs
+++ b/src/input.rs
@@ -309,14 +309,12 @@ impl InputHandler {
         self.last_cursor_move = Instant::now();
 
         let action = match physical_key {
-            PhysicalKey::Code(KeyCode::Escape) => {
-                match ctx.front_overlay {
-                    Some(OverlayKind::Gallery) => Some(InputAction::ToggleGallery),
-                    Some(OverlayKind::Help) => Some(InputAction::ToggleHelpOverlay),
-                    Some(OverlayKind::Settings) => Some(InputAction::ToggleSettings),
-                    None => Some(InputAction::Exit),
-                }
-            }
+            PhysicalKey::Code(KeyCode::Escape) => match ctx.front_overlay {
+                Some(OverlayKind::Gallery) => Some(InputAction::ToggleGallery),
+                Some(OverlayKind::Help) => Some(InputAction::ToggleHelpOverlay),
+                Some(OverlayKind::Settings) => Some(InputAction::ToggleSettings),
+                None => Some(InputAction::Exit),
+            },
             PhysicalKey::Code(KeyCode::KeyQ) => Some(InputAction::Exit),
             PhysicalKey::Code(KeyCode::ArrowRight) | PhysicalKey::Code(KeyCode::Space) => {
                 let steps = if modifiers.shift_key() { 10 } else { 1 };


### PR DESCRIPTION
Closes #286

## Overview
`ts_blind()` was treating direction 0/1 identically and direction 2/3 identically, making modes 12-15 produce only two visually distinct effects instead of four.

## Changes
- Add `open_outward` boolean to `ts_blind()` to differentiate open vs. close direction
- Mode 12: horizontal blinds, open outward (`slice_progress < progress`)
- Mode 13: horizontal blinds, close inward (`slice_progress > 1.0 - progress`)
- Mode 14: vertical blinds, open outward
- Mode 15: vertical blinds, close inward
- Fix incidental `rustfmt` formatting in `src/input.rs`

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed
- [x] `cargo build --release` passed
- [x] Manual visual testing recommended (see command below)
