### PR TITLE
fix: make Rgba16Float swapchain opt-in to restore SDR brightness

### DIFF
--- a/example.sldshow
+++ b/example.sldshow
@@ -33,6 +33,10 @@ filter_mode = "linear"           # Texture filtering: "linear" (smooth) or "near
 fit_mode = "AmbientFit"          # "Fit" = black bars, "AmbientFit" = blurred background
                                  # Toggle at runtime with 'A' key
 ambient_blur = 5.0               # Mip LOD level for AmbientFit blur (0-10, higher = blurrier)
+# hdr = false                    # Enable Rgba16Float swapchain for HDR displays (Windows Advanced Color).
+                                 # Default false — keeps correct SDR brightness on most displays.
+                                 # Set true only if your display has HDR mode enabled and you need
+                                 # full dynamic range for EXR files.
 
 [transition]
 time = 0.5              # Transition duration in seconds

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,10 @@ pub struct ViewerConfig {
     /// Mip LOD level for ambient fit blur (higher = blurrier, default 5.0)
     #[validate(range(min = 0.0, max = 10.0))]
     pub ambient_blur: f32,
+    /// Enable HDR output (Rgba16Float swapchain) for HDR displays with Windows Advanced Color.
+    /// When false (default), uses Rgba8UnormSrgb for correct SDR image brightness.
+    /// Set to true only if your display has HDR enabled and you need full HDR range for EXR files.
+    pub hdr: bool,
 }
 
 impl Default for ViewerConfig {
@@ -150,6 +154,7 @@ impl Default for ViewerConfig {
             filter_mode: FilterMode::Linear,
             fit_mode: FitMode::Fit,
             ambient_blur: 5.0,
+            hdr: false,
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -62,7 +62,7 @@ impl Renderer {
 
         let caps = surface.get_capabilities(&adapter);
         let hdr_fmt = wgpu::TextureFormat::Rgba16Float;
-        let (config_format, is_hdr) = if caps.formats.contains(&hdr_fmt) {
+        let (config_format, is_hdr) = if config.viewer.hdr && caps.formats.contains(&hdr_fmt) {
             info!("HDR swapchain selected: Rgba16Float");
             (hdr_fmt, true)
         } else {


### PR DESCRIPTION
## Problem

Since the HDR swapchain feature was added, SDR images (PNG, JPEG, etc.) appear noticeably darker and more muted on HDR-enabled displays.

**Root cause**: On Windows with Advanced Color (HDR) enabled, an `Rgba16Float` swapchain uses scRGB colorspace where `1.0 = 80 nits`. SDR reference white is ~203 nits, so SDR images render at roughly 40% of expected brightness. Before this regression, the `Rgba8UnormSrgb` swapchain provided automatic sRGB encoding, which always displayed SDR images at the correct brightness.

The previous code selected `Rgba16Float` automatically whenever the GPU supported it — which is true for virtually all modern GPUs, regardless of whether the display actually has HDR mode enabled.

## Changes

- **`src/config.rs`**: Added `hdr: bool` field to `ViewerConfig` (default `false`)
- **`src/renderer.rs`**: Gate `Rgba16Float` swapchain selection on `config.viewer.hdr == true`
- **`example.sldshow`**: Document the new `hdr` config option (commented out by default)

## Behavior

| Config | Swapchain | Result |
|---|---|---|
| `hdr = false` (default) | `Rgba8UnormSrgb` | SDR images at correct brightness (restored original behavior) |
| `hdr = true` | `Rgba16Float` | Full HDR range for EXR files on HDR-enabled displays |

## Testing

- [x] `cargo fmt --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` — all 46 tests passed (including GPU transition tests)
- [ ] Visual: SDR images should match pre-HDR brightness on an HDR display with `hdr = false`
- [ ] Visual: EXR images should display correctly with `hdr = true` on an HDR display
