### PR TITLE
fix: add libfontconfig1-dev to Linux CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev
+          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features
 
@@ -45,7 +45,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev
+          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features -- -D warnings
 
@@ -58,7 +58,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev
+          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 


### PR DESCRIPTION
## Summary
- Linux CI (Check, Clippy, Test) が `servo-fontconfig-sys` のビルド時に `freetype2` ヘッダー不足で失敗していた問題を修正
- 3ジョブの `apt-get install` に `libfontconfig1-dev` を追加（`libfreetype6-dev` は依存で自動インストール）

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)