### PR TITLE
feat: show transition mode name in settings panel slider

### DIFF
--- a/assets/shaders/transition.wgsl
+++ b/assets/shaders/transition.wgsl
@@ -1,6 +1,8 @@
 // Transition shader for sldshow2
 // Ported from original sldshow with updated WGSL syntax
-// 20 different transition effects
+//
+// Mode indices assigned here must stay in sync with TransitionMode::name()
+// and TransitionMode::MAX in src/config.rs.
 
 // Vertex output structure
 struct VertexOutput {
@@ -358,7 +360,8 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         return apply_color_adjustments(sample_b(in.uv));
     }
 
-    // Route to appropriate transition effect
+    // Route to appropriate transition effect.
+    // Mode assignments mirror TransitionMode::name() in src/config.rs.
     var result: vec4<f32>;
     if mode == 0 {
         result = ts_crossfading(in.uv, progress);

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,10 @@ impl Default for ViewerConfig {
 ///
 /// Enforces the range invariant at construction time via [`TryFrom<i32>`].
 /// Serializes and deserializes as a plain integer for TOML compatibility.
+///
+/// The mode index must stay in sync with the WGSL router and the mode list
+/// comment at the top of `assets/shaders/transition.wgsl`. When adding or
+/// renaming a mode, update both files together.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct TransitionMode(i32);
 
@@ -171,6 +175,35 @@ impl TransitionMode {
     #[inline]
     pub fn value(self) -> i32 {
         self.0
+    }
+
+    /// Human-readable name for this transition mode.
+    ///
+    /// Must stay in sync with the WGSL router in `assets/shaders/transition.wgsl`.
+    pub fn name(self) -> &'static str {
+        match self.0 {
+            0 => "Crossfade",
+            1 => "Smooth Crossfade",
+            2 => "Roll from Top",
+            3 => "Roll from Bottom",
+            4 => "Roll from Left",
+            5 => "Roll from Right",
+            6 => "Roll from Top-Left",
+            7 => "Roll from Top-Right",
+            8 => "Roll from Bottom-Left",
+            9 => "Roll from Bottom-Right",
+            10 => "Sliding Door Open",
+            11 => "Sliding Door Close",
+            12 => "Blinds H Open",
+            13 => "Blinds H Close",
+            14 => "Blinds V Open",
+            15 => "Blinds V Close",
+            16 => "Box Expand",
+            17 => "Box Contract",
+            18 => "Random Squares",
+            19 => "Angular Wipe",
+            _ => "Unknown",
+        }
     }
 }
 

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -561,7 +561,18 @@ impl EguiOverlay {
                         ui.horizontal(|ui| {
                             ui.label("Transition Mode:");
                             let mut mode_val: i32 = config.transition.mode.into();
-                            if ui.add(egui::Slider::new(&mut mode_val, 0..=19)).changed() {
+                            if ui
+                                .add(
+                                    egui::Slider::new(&mut mode_val, 0..=19)
+                                        .custom_formatter(|n, _| {
+                                            TransitionMode::try_from(n as i32)
+                                                .map(|m| format!("{} — {}", n as i32, m.name()))
+                                                .unwrap_or_else(|_| format!("{}", n as i32))
+                                        })
+                                        .custom_parser(|s| s.trim().parse::<f64>().ok()),
+                                )
+                                .changed()
+                            {
                                 // Value comes from a bounded slider so try_from always succeeds.
                                 if let Ok(m) = TransitionMode::try_from(mode_val) {
                                     config.transition.mode = m;


### PR DESCRIPTION
## Summary

- Add `TransitionMode::name()` mapping each mode index to a human-readable name
- Apply `custom_formatter` to the settings panel slider so it displays e.g. `7 — Roll from Top-Right` instead of just `7`
- Add cross-reference comments between `config.rs` and `transition.wgsl` so both files are kept in sync when modes are added or renamed

## Test plan

- [x] Open the settings panel and disable Random Transitions
- [x] Drag the Transition Mode slider and confirm the value label shows `{n} — {name}` format
