### PR TITLE
ci: remove empty Test job from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features -- -D warnings
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libasound2-dev libudev-dev libxkbcommon-dev libwayland-dev libfontconfig1-dev
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+  # TODO: Re-add test job once unit tests exist (see issue #294).
+  # The job was removed because it ran zero tests, wasting 16+ minutes of CI time
+  # while duplicating the Check job. When tests are added, use #[cfg(test)] mod tests
+  # inside each .rs file rather than separate files under tests/ to avoid expensive
+  # per-binary link times. Reference: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
   check-windows:
     name: Check (Windows)


### PR DESCRIPTION
Closes #294

## Overview

Remove the `test` CI job that ran zero tests, wasting 16+ minutes of CI time per run while duplicating the `check` job's compilation work.

## Changes

- Deleted the `test` job from `.github/workflows/ci.yml`
- Added a TODO comment explaining the removal and the correct approach for re-adding it when unit tests are written (`#[cfg(test)] mod tests` inside `.rs` files, not separate `tests/` binaries)

## Rationale

A job named `test` that runs no tests is a misleading interface — it signals correctness guarantees that don't exist. Per *A Philosophy of Software Design*, a module whose interface lies about its behavior adds complexity rather than reducing it. Deletion is the honest design choice; the TODO comment preserves intent without the false signal.

## Testing

- [x] All quality gate checks passed (fmt, clippy, check, check-windows)
- [x] No functional code changed — CI-only
