### PR TITLE
test: add unit tests for pure logic modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ cargo build                           # Compile check only
 
 **IMPORTANT**: Always use `--release` for visual/performance testing. Debug builds of `image` and `wgpu` are slow and cause frame stutters that don't reflect production behavior.
 
-No unit tests — testing is manual only.
+```bash
+cargo test                            # Run unit tests (no GPU required)
+```
 
 ## Architecture
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,4 +439,52 @@ mod tests {
             _ => panic!("Expected ConfigSaveError, got {:?}", result),
         }
     }
+
+    #[test]
+    fn test_fitmode_toggle() {
+        let mut mode = FitMode::Fit;
+        mode.toggle();
+        assert_eq!(mode, FitMode::AmbientFit);
+        mode.toggle();
+        assert_eq!(mode, FitMode::Fit);
+    }
+
+    #[test]
+    fn test_fitmode_uniform_values() {
+        assert_eq!(FitMode::Fit.to_uniform_value(), 0);
+        assert_eq!(FitMode::AmbientFit.to_uniform_value(), 1);
+    }
+
+    #[test]
+    fn test_bg_color_f32_conversion() {
+        let mut config = Config::default();
+        config.style.bg_color = [0, 128, 255, 255];
+        let c = config.bg_color_f32();
+        assert_eq!(c[0], 0.0);
+        assert!((c[1] - 128.0 / 255.0).abs() < 1e-6);
+        assert!((c[2] - 1.0).abs() < 1e-6);
+        assert_eq!(c[3], 1.0);
+    }
+
+    #[test]
+    fn test_transition_mode_all_names_known() {
+        for i in TransitionMode::MIN..=TransitionMode::MAX {
+            let mode = TransitionMode::try_from(i).unwrap();
+            assert_ne!(
+                mode.name(),
+                "Unknown",
+                "TransitionMode({i}) returned Unknown — update name() to match"
+            );
+        }
+    }
+
+    #[test]
+    fn test_window_config_defaults() {
+        let w = WindowConfig::default();
+        assert_eq!(w.width, 1280);
+        assert_eq!(w.height, 720);
+        assert!(!w.fullscreen);
+        assert!(!w.always_on_top);
+        assert!(w.decorations);
+    }
 }

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -808,3 +808,152 @@ fn scan_directory_recursive_parallel(
 fn is_supported_image(path: &Path) -> bool {
     image::ImageFormat::from_path(path).is_ok()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_manager(paths: &[&str]) -> TextureManager {
+        let mut mgr = TextureManager::new(2, (1920, 1080));
+        mgr.paths = paths.iter().map(|&s| Utf8PathBuf::from(s)).collect();
+        mgr.original_paths = mgr.paths.clone();
+        mgr
+    }
+
+    // --- next() ---
+
+    #[test]
+    fn next_advances_index() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
+        assert!(mgr.next(false));
+        assert_eq!(mgr.current_index, 1);
+    }
+
+    #[test]
+    fn next_wraps_to_start_when_not_pause_at_last() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg"]);
+        mgr.current_index = 1;
+        assert!(mgr.next(false));
+        assert_eq!(mgr.current_index, 0);
+    }
+
+    #[test]
+    fn next_returns_false_and_stays_at_last_when_pause_at_last() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg"]);
+        mgr.current_index = 1;
+        assert!(!mgr.next(true));
+        assert_eq!(mgr.current_index, 1);
+    }
+
+    #[test]
+    fn next_returns_false_on_empty() {
+        let mut mgr = TextureManager::new(2, (1920, 1080));
+        assert!(!mgr.next(false));
+    }
+
+    // --- previous() ---
+
+    #[test]
+    fn previous_decrements_index() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
+        mgr.current_index = 2;
+        assert!(mgr.previous());
+        assert_eq!(mgr.current_index, 1);
+    }
+
+    #[test]
+    fn previous_wraps_to_last() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
+        mgr.current_index = 0;
+        assert!(mgr.previous());
+        assert_eq!(mgr.current_index, 2);
+    }
+
+    #[test]
+    fn previous_returns_false_on_empty() {
+        let mut mgr = TextureManager::new(2, (1920, 1080));
+        assert!(!mgr.previous());
+    }
+
+    // --- jump_to() ---
+
+    #[test]
+    fn jump_to_valid_index() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
+        mgr.jump_to(2);
+        assert_eq!(mgr.current_index, 2);
+    }
+
+    #[test]
+    fn jump_to_out_of_bounds_is_ignored() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg"]);
+        mgr.jump_to(99);
+        assert_eq!(mgr.current_index, 0);
+    }
+
+    // --- replace_paths() / append_paths() ---
+
+    #[test]
+    fn replace_paths_resets_to_index_zero() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg"]);
+        mgr.current_index = 1;
+        mgr.replace_paths(vec![Utf8PathBuf::from("c.jpg")]);
+        assert_eq!(mgr.current_index, 0);
+        assert_eq!(mgr.paths.len(), 1);
+        assert!(mgr.textures.is_empty());
+    }
+
+    #[test]
+    fn append_paths_extends_list_and_preserves_index() {
+        let mut mgr = make_manager(&["a.jpg"]);
+        mgr.append_paths(vec![Utf8PathBuf::from("b.jpg"), Utf8PathBuf::from("c.jpg")]);
+        assert_eq!(mgr.paths.len(), 3);
+        assert_eq!(mgr.current_index, 0);
+    }
+
+    #[test]
+    fn append_paths_to_empty_behaves_like_replace() {
+        let mut mgr = TextureManager::new(2, (1920, 1080));
+        mgr.append_paths(vec![Utf8PathBuf::from("a.jpg"), Utf8PathBuf::from("b.jpg")]);
+        assert_eq!(mgr.paths.len(), 2);
+        assert_eq!(mgr.current_index, 0);
+    }
+
+    // --- mip_level_count() ---
+
+    #[test]
+    fn mip_level_count_1x1() {
+        assert_eq!(mip_level_count(1, 1), 1);
+    }
+
+    #[test]
+    fn mip_level_count_1024x1024() {
+        // ilog2(1024) = 10, so 11 levels
+        assert_eq!(mip_level_count(1024, 1024), 11);
+    }
+
+    #[test]
+    fn mip_level_count_non_square_uses_max_dim() {
+        // max dim = 1920, ilog2(1920) = 10, so 11 levels
+        assert_eq!(mip_level_count(1920, 1080), 11);
+    }
+
+    // --- linear_to_srgb() ---
+
+    #[test]
+    fn linear_to_srgb_zero_maps_to_zero() {
+        assert_eq!(linear_to_srgb(0.0), 0.0);
+    }
+
+    #[test]
+    fn linear_to_srgb_one_maps_to_one() {
+        assert!((linear_to_srgb(1.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_to_srgb_low_value_uses_linear_segment() {
+        // Values <= 0.003_130_8 use the linear c * 12.92 branch
+        let v = 0.001_f32;
+        assert!((linear_to_srgb(v) - v * 12.92).abs() < 1e-6);
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -182,4 +182,73 @@ mod tests {
         assert_eq!(frames, 3);
         assert!((timer.accumulator - 0.05).abs() < 0.001);
     }
+
+    // --- SlideshowTimer ---
+
+    #[test]
+    fn slideshow_timer_zero_interval_starts_paused() {
+        let timer = SlideshowTimer::new(0.0);
+        assert!(timer.paused);
+    }
+
+    #[test]
+    fn slideshow_timer_negative_interval_starts_paused() {
+        let timer = SlideshowTimer::new(-1.0);
+        assert!(timer.paused);
+    }
+
+    #[test]
+    fn slideshow_timer_positive_interval_not_paused() {
+        let timer = SlideshowTimer::new(5.0);
+        assert!(!timer.paused);
+        assert!((timer.interval_secs() - 5.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn slideshow_timer_toggle_pause_flips_state() {
+        let mut timer = SlideshowTimer::new(5.0);
+        let now_paused = timer.toggle_pause();
+        assert!(now_paused);
+        assert!(timer.paused);
+        let now_paused = timer.toggle_pause();
+        assert!(!now_paused);
+        assert!(!timer.paused);
+    }
+
+    #[test]
+    fn slideshow_timer_set_duration_zero_pauses() {
+        let mut timer = SlideshowTimer::new(5.0);
+        timer.set_duration(0.0);
+        assert!(timer.paused);
+    }
+
+    #[test]
+    fn slideshow_timer_set_duration_positive_unpauses_and_updates_interval() {
+        let mut timer = SlideshowTimer::new(0.0);
+        assert!(timer.paused);
+        timer.set_duration(3.0);
+        assert!(!timer.paused);
+        assert!((timer.interval_secs() - 3.0).abs() < 1e-5);
+    }
+
+    // --- SequenceTimer ---
+
+    #[test]
+    fn sequence_timer_invalid_fps_defaults_to_one() {
+        assert_eq!(SequenceTimer::new(-5.0).fps, 1.0);
+        assert_eq!(SequenceTimer::new(0.0).fps, 1.0);
+        assert_eq!(SequenceTimer::new(f32::NAN).fps, 1.0);
+    }
+
+    #[test]
+    fn advance_by_zero_dt_returns_no_frames() {
+        let mut timer = SequenceTimer::new(10.0);
+        assert_eq!(timer.advance_by(0.0), 0);
+    }
+
+    #[test]
+    fn advance_by_negative_dt_returns_no_frames() {
+        let mut timer = SequenceTimer::new(10.0);
+        assert_eq!(timer.advance_by(-1.0), 0);
+    }
 }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -209,3 +209,33 @@ impl TransitionPipeline {
             .expect("random_range(0..20) always produces a valid TransitionMode")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TransitionMode;
+
+    #[test]
+    fn transition_uniform_size_is_multiple_of_16() {
+        // WGSL uniform buffers must be 16-byte aligned.
+        assert_eq!(
+            std::mem::size_of::<TransitionUniform>() % 16,
+            0,
+            "TransitionUniform size must be a multiple of 16 bytes for WGSL alignment"
+        );
+    }
+
+    #[test]
+    fn transition_uniform_size_matches_field_layout() {
+        // Freeze the exact struct size so accidental field changes are caught.
+        // Update this value only when deliberately changing the struct layout.
+        assert_eq!(std::mem::size_of::<TransitionUniform>(), 112);
+    }
+
+    #[test]
+    fn transition_mode_count_matches_config_max() {
+        // TRANSITION_MODE_COUNT must equal TransitionMode::MAX + 1 so that
+        // random_mode() never produces an out-of-range index.
+        assert_eq!(TRANSITION_MODE_COUNT, TransitionMode::MAX + 1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #245

Establishes the project-wide unit testing baseline described in #245. All tests are GPU-free inline `#[cfg(test)]` modules, consistent with the project's preference for per-`.rs` unit tests over separate integration binaries.

### Tests added (52 total, all passing)

| Module | New tests | What they cover |
|---|---|---|
| `transition.rs` | 3 | `TransitionUniform` size frozen at 112 bytes, 16-byte alignment, `TRANSITION_MODE_COUNT == MAX+1` |
| `image_loader.rs` | 14 | `next`/`previous`/`jump_to` navigation, `replace_paths`/`append_paths`, `mip_level_count`, `linear_to_srgb` |
| `timer.rs` | 8 | `SlideshowTimer` pause/resume/duration, `SequenceTimer` invalid-fps fallback, edge-case dt values |
| `config.rs` | 5 | `FitMode::toggle`, uniform values, `bg_color_f32`, all 20 mode names known, `WindowConfig` defaults |

### Docs updated

- `CLAUDE.md`: replaced "No unit tests — testing is manual only" with `cargo test` command