### PR TITLE
fix: previous() respects pause_at_last; remove dead EguiOverlay getters

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -614,7 +614,10 @@ impl ApplicationState {
 
     fn prev_image(&mut self) {
         let old_index = self.texture_manager.current_index;
-        if self.texture_manager.previous() {
+        if self
+            .texture_manager
+            .previous(self.config.viewer.pause_at_last)
+        {
             self.finish_navigation(old_index);
         }
     }

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -148,14 +148,16 @@ impl TextureManager {
         }
     }
 
-    pub fn previous(&mut self) -> bool {
+    pub fn previous(&mut self, pause_at_last: bool) -> bool {
         if self.paths.is_empty() {
             return false;
         }
         if self.current_index > 0 {
             self.current_index -= 1;
-        } else {
+        } else if !pause_at_last {
             self.current_index = self.paths.len() - 1;
+        } else {
+            return false;
         }
         true
     }
@@ -857,7 +859,7 @@ mod tests {
     fn previous_decrements_index() {
         let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
         mgr.current_index = 2;
-        assert!(mgr.previous());
+        assert!(mgr.previous(false));
         assert_eq!(mgr.current_index, 1);
     }
 
@@ -865,14 +867,22 @@ mod tests {
     fn previous_wraps_to_last() {
         let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
         mgr.current_index = 0;
-        assert!(mgr.previous());
+        assert!(mgr.previous(false));
         assert_eq!(mgr.current_index, 2);
+    }
+
+    #[test]
+    fn previous_returns_false_and_stays_at_first_when_pause_at_last() {
+        let mut mgr = make_manager(&["a.jpg", "b.jpg", "c.jpg"]);
+        mgr.current_index = 0;
+        assert!(!mgr.previous(true));
+        assert_eq!(mgr.current_index, 0);
     }
 
     #[test]
     fn previous_returns_false_on_empty() {
         let mut mgr = TextureManager::new(2, (1920, 1080));
-        assert!(!mgr.previous());
+        assert!(!mgr.previous(false));
     }
 
     // --- jump_to() ---

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -260,12 +260,6 @@ impl EguiOverlay {
         self.show_help_overlay
     }
 
-    /// Check if help overlay is visible
-    #[allow(dead_code)]
-    pub fn help_overlay_visible(&self) -> bool {
-        self.show_help_overlay
-    }
-
     /// Toggle settings overlay visibility
     pub fn toggle_settings(&mut self) -> bool {
         self.show_settings = !self.show_settings;
@@ -277,12 +271,6 @@ impl EguiOverlay {
         self.show_settings
     }
 
-    /// Check if settings overlay is visible
-    #[allow(dead_code)]
-    pub fn settings_visible(&self) -> bool {
-        self.show_settings
-    }
-
     /// Toggle gallery visibility
     pub fn toggle_gallery(&mut self) {
         self.show_gallery = !self.show_gallery;
@@ -291,12 +279,6 @@ impl EguiOverlay {
         } else {
             self.pop_overlay(OverlayKind::Gallery);
         }
-    }
-
-    /// Check if gallery is visible
-    #[allow(dead_code)]
-    pub fn gallery_visible(&self) -> bool {
-        self.show_gallery
     }
 
     /// Returns `true` when any overlay or the OSC is currently visible,


### PR DESCRIPTION
## Summary

Closes #302
Closes #303

### #302 — `previous()` ignores `pause_at_last`

`previous()` was unconditionally wrapping from the first image to the last, inconsistent with `next()` which already respects `pause_at_last`. Fixed by adding the parameter and updating the caller in `app.rs`.

- `image_loader.rs`: `previous()` now accepts `pause_at_last: bool`; returns `false` without changing index when at the first image and flag is set
- `app.rs`: passes `self.config.viewer.pause_at_last` to `previous()`
- Tests: existing tests updated for new signature; new test `previous_returns_false_and_stays_at_first_when_pause_at_last` added

### #303 — Dead `EguiOverlay` visibility getters

Removed `help_overlay_visible()`, `settings_visible()`, and `gallery_visible()` from `overlay.rs`. All three carried `#[allow(dead_code)]` and were never called; `is_active()` and `front_overlay()` cover the actual use cases.