### PR TITLE
fix: clear thumbnail cache after drag-drop path replace

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -984,6 +984,7 @@ impl ApplicationState {
                             info!("Drag & drop: appended {} images", count);
                         } else {
                             self.texture_manager.replace_paths(new_paths);
+                            self.thumbnail_manager.clear();
                             self.transition = None;
                             self.renderer.invalidate_bind_group();
                             self.current_texture_index = if count > 0 { Some(0) } else { None };

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -160,8 +160,6 @@ impl ThumbnailManager {
     /// Increments the internal epoch so any in-flight rayon tasks spawned
     /// before this call are treated as stale: their results are silently
     /// discarded in `update()` without touching the refreshed cache.
-    // Not currently called from app code, but retained as a complete cache-management API.
-    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.cache.clear();
         self.loading_tasks.clear();


### PR DESCRIPTION
Closes #299
Closes #304

## Overview

Wires `ThumbnailManager::clear()` into the drag-drop path replace flow so gallery thumbnails are immediately invalidated when the image list changes.

## Changes

- `src/thumbnail.rs`: Remove `#[allow(dead_code)]` and stale comment from `clear()` — it is now called from app code
- `src/app.rs`: Call `thumbnail_manager.clear()` after `texture_manager.replace_paths()` on drag-drop replace; the epoch bump in `clear()` causes any in-flight generation tasks to be silently discarded

## Testing

- [x] All quality gate checks passed (`cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `cargo build --release`)
- [x] Manual: drag-drop a new folder → gallery should show "Loading…" for all cells (no old thumbnails)
