### PR TITLE
fix: apply EXIF orientation when copying image to clipboard

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -4,16 +4,31 @@ use anyhow::{Context, Result};
 use arboard::{Clipboard, ImageData};
 use camino::Utf8Path;
 use std::borrow::Cow;
+use std::io::{BufReader, Seek, SeekFrom};
+
+use crate::image_loader::{apply_orientation, read_exif_orientation};
 
 /// Copies the image at the given path to the system clipboard.
 ///
 /// Re-reads the image from disk to avoid holding large bitmaps in RAM.
-/// The image is converted to RGBA format for clipboard compatibility.
+/// Applies EXIF orientation so the copied image matches the viewer display.
 pub fn copy_image_to_clipboard(path: &Utf8Path) -> Result<()> {
-    // Re-read from disk to save RAM
-    let img = image::open(path)
-        .with_context(|| format!("Failed to read image from {}", path))?
-        .to_rgba8();
+    let file = std::fs::File::open(path.as_std_path())
+        .with_context(|| format!("Failed to open image from {}", path))?;
+    let mut reader = BufReader::new(file);
+
+    let orientation = read_exif_orientation(&mut reader);
+    reader
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("Failed to seek image: {}", path))?;
+
+    let img = image::ImageReader::new(&mut reader)
+        .with_guessed_format()
+        .with_context(|| format!("Failed to guess image format: {}", path))?
+        .decode()
+        .with_context(|| format!("Failed to decode image from {}", path))?;
+
+    let img = apply_orientation(img, orientation).to_rgba8();
 
     let width = img.width() as usize;
     let height = img.height() as usize;


### PR DESCRIPTION
## Summary

- Fix clipboard copy ignoring EXIF orientation, causing rotated/flipped images to be pasted incorrectly
- Reuse existing `read_exif_orientation()` + `apply_orientation()` from `image_loader.rs` instead of `image::open()`

Closes #319

## Test plan

- [x] Open a JPEG with EXIF orientation tag (e.g., portrait photo from phone)
- [x] Press `Ctrl+Shift+C` to copy to clipboard
- [x] Paste into an image editor — verify orientation matches the viewer display

🤖 Generated with [Claude Code](https://claude.com/claude-code)