### PR TITLE
fix: reject timer values between 0 and 0.1 in config validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,11 @@ pub struct ViewerConfig {
 }
 
 fn validate_timer(value: f32) -> std::result::Result<(), validator::ValidationError> {
+    if !value.is_finite() {
+        let mut err = validator::ValidationError::new("timer_finite");
+        err.message = Some(std::borrow::Cow::Borrowed("timer must be a finite number"));
+        return Err(err);
+    }
     if value == 0.0 || value >= 0.1 {
         Ok(())
     } else {
@@ -531,6 +536,17 @@ mod tests {
     fn test_timer_validation_negative_is_invalid() {
         let mut config = ViewerConfig::default();
         config.timer = -1.0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_timer_validation_non_finite_is_invalid() {
+        let mut config = ViewerConfig::default();
+        config.timer = f32::INFINITY;
+        assert!(config.validate().is_err());
+        config.timer = f32::NEG_INFINITY;
+        assert!(config.validate().is_err());
+        config.timer = f32::NAN;
         assert!(config.validate().is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Replace `range(min=0.0)` with custom `validate_timer` that accepts exactly `0.0` (paused) or `>= 0.1` seconds
- Values in `(0.0, 0.1)` now produce a validation error instead of being silently clamped
- Negative values also rejected by the custom validator

## Test plan
- [x] `timer = 0.0` remains valid (starts paused)
- [x] `timer = 0.1` and above remain valid
- [x] `timer = 0.05`, `0.01`, `0.099` rejected
- [x] Negative values rejected
- [x] All existing tests pass

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)