### PR TITLE
refactor: unify overlay toggle methods via shared helper function

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -912,3 +912,41 @@ impl EguiOverlay {
         action
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_overlay_enables_and_pushes() {
+        let mut stack = Vec::new();
+        let shown = toggle_overlay(&mut stack, OverlayKind::Help, false);
+        assert!(shown);
+        assert_eq!(stack, vec![OverlayKind::Help]);
+    }
+
+    #[test]
+    fn toggle_overlay_disables_and_removes() {
+        let mut stack = vec![OverlayKind::Help];
+        let shown = toggle_overlay(&mut stack, OverlayKind::Help, true);
+        assert!(!shown);
+        assert!(stack.is_empty());
+    }
+
+    #[test]
+    fn toggle_overlay_pushes_to_top_of_stack() {
+        let mut stack = vec![OverlayKind::Settings];
+        let shown = toggle_overlay(&mut stack, OverlayKind::Help, false);
+        assert!(shown);
+        assert_eq!(stack, vec![OverlayKind::Settings, OverlayKind::Help]);
+    }
+
+    #[test]
+    fn toggle_overlay_removes_duplicates_before_push() {
+        let mut stack = vec![OverlayKind::Help, OverlayKind::Settings];
+        // Re-enable Help (already in stack) — should move to top
+        let shown = toggle_overlay(&mut stack, OverlayKind::Help, false);
+        assert!(shown);
+        assert_eq!(stack, vec![OverlayKind::Settings, OverlayKind::Help]);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `toggle_overlay()` free function for shared show/hide + stack logic
- All three toggle methods (`toggle_help_overlay`, `toggle_settings`, `toggle_gallery`) delegate to it
- `toggle_gallery` now returns `bool` like the other two
- Remove unused `push_overlay` method (logic moved to free function)

## Test plan
- [x] All existing tests pass
- [x] clippy clean
- [x] Visual: overlays open/close correctly, stack ordering preserved

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)