### PR TITLE
refactor: centralize timer validation as single source of truth

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ use crate::overlay::EguiOverlay;
 use crate::renderer::Renderer;
 use crate::screenshot::ScreenshotCapture;
 use crate::thumbnail::ThumbnailManager;
-use crate::timer::{SequenceTimer, SlideshowTimer};
+use crate::timer::{SequenceTimer, SlideshowTimer, sanitize_timer};
 use crate::transition::{self, TransitionPipeline, TransitionUniform};
 
 /// Color adjustment parameters (mpv-like).
@@ -905,8 +905,14 @@ impl ApplicationState {
             match action {
                 OverlayAction::Osc(osc_action) => self.execute_osc_action(osc_action),
                 OverlayAction::SetTimer(timer) => {
-                    self.slideshow.set_duration(timer);
-                    self.show_osd(format!("Timer: {:.1}s", timer));
+                    let sanitized = sanitize_timer(timer);
+                    self.slideshow.set_duration(sanitized);
+                    self.config.viewer.timer = sanitized;
+                    if sanitized <= 0.0 {
+                        self.show_osd("Timer: 0.0s (Paused)".to_string());
+                    } else {
+                        self.show_osd(format!("Timer: {:.1}s", sanitized));
+                    }
                 }
                 OverlayAction::ToggleShuffle(enabled) => {
                     self.shuffle_enabled = enabled;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,14 @@ use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use validator::Validate;
 
+/// Minimum valid slideshow timer interval in seconds.
+///
+/// `0.0` is the sentinel for "paused". Values in `(0.0, TIMER_MIN)` are
+/// rejected by config validation and clamped by the runtime timer.
+/// This is the single source of truth referenced by `validate_timer`,
+/// `timer::sanitize_timer`, and the settings UI.
+pub const TIMER_MIN: f32 = 0.1;
+
 /// Texture filtering mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -141,13 +149,13 @@ fn validate_timer(value: f32) -> std::result::Result<(), validator::ValidationEr
         err.message = Some(std::borrow::Cow::Borrowed("timer must be a finite number"));
         return Err(err);
     }
-    if value == 0.0 || value >= 0.1 {
+    if value == 0.0 || value >= TIMER_MIN {
         Ok(())
     } else {
         let mut err = validator::ValidationError::new("timer_range");
-        err.message = Some(std::borrow::Cow::Borrowed(
-            "timer must be 0.0 (paused) or >= 0.1 seconds",
-        ));
+        err.message = Some(std::borrow::Cow::Owned(format!(
+            "timer must be 0.0 (paused) or >= {TIMER_MIN} seconds"
+        )));
         Err(err)
     }
 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -8,7 +8,7 @@ use wgpu::{Device, Queue, TextureFormat};
 use winit::event::WindowEvent;
 use winit::window::Window;
 
-use crate::config::{Config, FitMode, TransitionMode};
+use crate::config::{Config, FitMode, TIMER_MIN, TransitionMode};
 use crate::hdr_ui_composite::{EGUI_HDR_INTERMEDIATE_FORMAT, HdrUiComposite};
 use crate::osc::{Osc, OscAction};
 use crate::thumbnail::ThumbnailManager;
@@ -525,7 +525,7 @@ impl EguiOverlay {
                         if ui
                             .add(
                                 egui::DragValue::new(&mut config.viewer.timer)
-                                    .speed(0.1)
+                                    .speed(TIMER_MIN)
                                     .range(0.0..=3600.0),
                             )
                             .changed()

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,6 +3,21 @@
 use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
+pub use crate::config::TIMER_MIN;
+
+/// Sanitize a raw timer value to a legal interval.
+///
+/// - Non-finite or `<= 0.0` → `0.0` (paused sentinel)
+/// - `(0.0, TIMER_MIN)` → clamped up to `TIMER_MIN`
+/// - `>= TIMER_MIN` → returned unchanged
+pub fn sanitize_timer(value: f32) -> f32 {
+    if !value.is_finite() || value <= 0.0 {
+        0.0
+    } else {
+        value.max(TIMER_MIN)
+    }
+}
+
 /// Shared pause/timing state embedded in both timer types.
 ///
 /// Provides the common `toggle_pause` and `reset` operations so the logic
@@ -57,9 +72,14 @@ impl DerefMut for SlideshowTimer {
 
 impl SlideshowTimer {
     pub fn new(interval_secs: f32) -> Self {
+        let sanitized = sanitize_timer(interval_secs);
         Self {
-            base: TimerBase::new(interval_secs <= 0.0),
-            interval: Duration::from_secs_f32(interval_secs.max(0.1)),
+            base: TimerBase::new(sanitized <= 0.0),
+            interval: Duration::from_secs_f32(if sanitized > 0.0 {
+                sanitized
+            } else {
+                TIMER_MIN
+            }),
             paused_by_user: false,
         }
     }
@@ -85,11 +105,12 @@ impl SlideshowTimer {
     }
 
     pub fn set_duration(&mut self, duration_secs: f32) {
-        if duration_secs <= 0.0 {
+        let sanitized = sanitize_timer(duration_secs);
+        if sanitized <= 0.0 {
             self.base.paused = true;
             self.paused_by_user = false;
         } else {
-            self.interval = Duration::from_secs_f32(duration_secs);
+            self.interval = Duration::from_secs_f32(sanitized);
             self.base.reset();
             if !self.paused_by_user {
                 self.base.paused = false;
@@ -329,5 +350,43 @@ mod tests {
     fn advance_by_negative_dt_returns_no_frames() {
         let mut timer = SequenceTimer::new(10.0);
         assert_eq!(timer.advance_by(-1.0), 0);
+    }
+
+    // --- sanitize_timer ---
+
+    #[test]
+    fn sanitize_timer_zero_returns_zero() {
+        assert_eq!(sanitize_timer(0.0), 0.0);
+    }
+
+    #[test]
+    fn sanitize_timer_negative_returns_zero() {
+        assert_eq!(sanitize_timer(-1.0), 0.0);
+        assert_eq!(sanitize_timer(-0.001), 0.0);
+    }
+
+    #[test]
+    fn sanitize_timer_non_finite_returns_zero() {
+        assert_eq!(sanitize_timer(f32::INFINITY), 0.0);
+        assert_eq!(sanitize_timer(f32::NEG_INFINITY), 0.0);
+        assert_eq!(sanitize_timer(f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn sanitize_timer_below_min_clamps_to_min() {
+        assert_eq!(sanitize_timer(0.0001), TIMER_MIN);
+        assert_eq!(sanitize_timer(0.05), TIMER_MIN);
+        assert!((sanitize_timer(TIMER_MIN - f32::EPSILON) - TIMER_MIN).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sanitize_timer_at_min_preserved() {
+        assert!((sanitize_timer(TIMER_MIN) - TIMER_MIN).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sanitize_timer_above_min_preserved() {
+        assert!((sanitize_timer(5.0) - 5.0).abs() < 1e-6);
+        assert!((sanitize_timer(3600.0) - 3600.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
Closes #344

## Overview

Centralizes the slideshow timer validity rules in a single source of truth: `TIMER_MIN` (defined in `config.rs`) and `sanitize_timer()` (defined in `timer.rs`). All three previously-divergent validation sites now derive from these shared definitions.

## Changes

- **`src/config.rs`**: Add `pub const TIMER_MIN: f32 = 0.1` as the single source of truth for the minimum valid timer interval. Update `validate_timer` to use `TIMER_MIN` instead of a hardcoded literal; error message now includes the actual constant value via `format!`.
- **`src/timer.rs`**: Re-export `TIMER_MIN` from `config`. Add `pub fn sanitize_timer(value: f32) -> f32` which maps non-finite/negative/zero to `0.0` (paused sentinel) and clamps sub-minimum positive values to `TIMER_MIN`. Update `SlideshowTimer::new` and `set_duration` to call `sanitize_timer`. Add 6 new unit tests covering all branches of `sanitize_timer`.
- **`src/overlay.rs`**: Import `TIMER_MIN` from `config`; use it as the DragValue `speed` so the drag step matches the minimum interval (range stays `0.0..=3600.0`).
- **`src/app.rs`**: Update the `SetTimer` handler to call `sanitize_timer`, write the corrected value back to `config.viewer.timer` so the UI reflects snapped values, and show "Paused" in the OSD when the sanitized value is `0.0`.

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (all 21 GPU transition tests + unit tests)
- [x] `cargo build --release` passed
- [x] Manual testing recommended: open Settings, type `0.05` into the Timer field, confirm it snaps to `0.1` in the UI
