### PR TITLE
refactor: split image_loader.rs into submodules

### DIFF
--- a/src/image_loader/decode.rs
+++ b/src/image_loader/decode.rs
@@ -1,0 +1,288 @@
+//! Image decoding, mipmap generation, and GPU-ready resizing.
+
+use camino::Utf8Path;
+use image::GenericImageView;
+
+use super::MipData;
+use super::exif::{apply_orientation, read_exif_orientation};
+
+/// Converts a linear light value to sRGB using the IEC 61966-2-1 piecewise transfer function.
+/// This is more accurate than the simple gamma 2.2 approximation, especially for near-black values.
+fn linear_to_srgb(c: f32) -> f32 {
+    if c <= 0.003_130_8 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+// Helper to perform fast resizing using fast_image_resize
+pub(crate) fn fast_resize(
+    src_img: fast_image_resize::images::Image,
+    dst_width: u32,
+    dst_height: u32,
+    filter: fast_image_resize::FilterType,
+) -> anyhow::Result<image::RgbaImage> {
+    // Create destination image
+    let mut dst_img = fast_image_resize::images::Image::new(
+        dst_width,
+        dst_height,
+        fast_image_resize::PixelType::U8x4,
+    );
+
+    // Create resizer
+    let mut resizer = fast_image_resize::Resizer::new();
+    let resize_opts = fast_image_resize::ResizeOptions::new()
+        .resize_alg(fast_image_resize::ResizeAlg::Convolution(filter));
+
+    // Resize
+    resizer
+        .resize(&src_img, &mut dst_img, &resize_opts)
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    // Convert back to image::RgbaImage
+    let buffer = dst_img.into_vec();
+    image::RgbaImage::from_raw(dst_width, dst_height, buffer)
+        .ok_or_else(|| anyhow::anyhow!("from_raw failed"))
+}
+
+pub(super) fn load_image_mips(
+    path: &Utf8Path,
+    max_size: (u32, u32),
+    is_hdr: bool,
+) -> anyhow::Result<MipData> {
+    use std::fs::File;
+    use std::io::{BufReader, Seek, SeekFrom};
+
+    let file = File::open(path.as_std_path())
+        .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
+    let mut reader = BufReader::new(file);
+
+    // Read EXIF orientation before decoding so we open the file only once.
+    let orientation = read_exif_orientation(&mut reader);
+    reader
+        .seek(SeekFrom::Start(0))
+        .map_err(|e| anyhow::anyhow!("Failed to seek image: {}", e))?;
+
+    let img = image::ImageReader::new(&mut reader)
+        .with_guessed_format()
+        .map_err(|e| anyhow::anyhow!("Failed to guess image format: {}", e))?
+        .decode()
+        .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
+
+    let is_exr = path.extension().unwrap_or("").eq_ignore_ascii_case("exr");
+
+    if is_hdr && is_exr {
+        // HDR path: keep linear float data as Rgba32F, skip sRGB conversion.
+        // GPU upload will convert f32 → f16 for Rgba16Float texture.
+        let rgba32f = img.into_rgba32f();
+        let img = apply_orientation(image::DynamicImage::ImageRgba32F(rgba32f), orientation);
+        let base = resize_for_gpu_hdr(img.into_rgba32f(), max_size.0, max_size.1);
+
+        // Generate mip chain using image::imageops (fast_image_resize is U8 only)
+        let mip_count = mip_level_count(base.width(), base.height());
+        let mut mips: Vec<image::Rgba32FImage> = Vec::with_capacity(mip_count as usize);
+        mips.push(base);
+
+        for _ in 1..mip_count {
+            let prev = mips.last().expect("mip chain is non-empty");
+            let new_w = (prev.width() / 2).max(1);
+            let new_h = (prev.height() / 2).max(1);
+            let resized =
+                image::imageops::resize(prev, new_w, new_h, image::imageops::FilterType::Triangle);
+            mips.push(resized);
+        }
+
+        Ok(MipData::Hdr(mips))
+    } else {
+        // SDR path: existing behavior — tonemap EXR to sRGB, upload as Rgba8UnormSrgb.
+        let mut img = img;
+        if is_exr {
+            // Apply the IEC 61966-2-1 piecewise sRGB transfer function per channel
+            let mut rgba32f = img.into_rgba32f();
+            for pixel in rgba32f.pixels_mut() {
+                pixel[0] = linear_to_srgb(pixel[0].max(0.0));
+                pixel[1] = linear_to_srgb(pixel[1].max(0.0));
+                pixel[2] = linear_to_srgb(pixel[2].max(0.0));
+                // Alpha remains linear
+            }
+            img = image::DynamicImage::ImageRgba32F(rgba32f);
+        }
+
+        let img = apply_orientation(img, orientation);
+        let base = resize_for_gpu(img, max_size.0, max_size.1)?.into_rgba8();
+
+        // Generate mipmap chain on CPU
+        let mip_count = mip_level_count(base.width(), base.height());
+        let mut mips = Vec::with_capacity(mip_count as usize);
+        mips.push(base);
+
+        for _ in 1..mip_count {
+            let prev = mips
+                .last()
+                .ok_or_else(|| anyhow::anyhow!("mip chain is empty"))?;
+            let new_w = (prev.width() / 2).max(1);
+            let new_h = (prev.height() / 2).max(1);
+
+            let mut prev_clone = prev.clone();
+
+            // Fast image resize wrapper creation
+            let src_image = fast_image_resize::images::Image::from_slice_u8(
+                prev.width(),
+                prev.height(),
+                prev_clone.as_mut(),
+                fast_image_resize::PixelType::U8x4,
+            )
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+            let resized = fast_resize(
+                src_image,
+                new_w,
+                new_h,
+                fast_image_resize::FilterType::Bilinear,
+            )?;
+            mips.push(resized);
+        }
+
+        Ok(MipData::Sdr(mips))
+    }
+}
+
+pub(super) fn mip_level_count(width: u32, height: u32) -> u32 {
+    let max_dim = width.max(height).max(1);
+    max_dim.ilog2() + 1
+}
+
+fn resize_for_gpu(
+    img: image::DynamicImage,
+    max_width: u32,
+    max_height: u32,
+) -> anyhow::Result<image::DynamicImage> {
+    // [0, 0] means "no limit" — upload at full resolution
+    if max_width == 0 || max_height == 0 {
+        return Ok(img);
+    }
+    let (orig_w, orig_h) = img.dimensions();
+    if orig_w <= max_width && orig_h <= max_height {
+        return Ok(img);
+    }
+    let scale_w = max_width as f32 / orig_w as f32;
+    let scale_h = max_height as f32 / orig_h as f32;
+    let scale = scale_w.min(scale_h);
+    let new_w = ((orig_w as f32 * scale).round() as u32).max(1);
+    let new_h = ((orig_h as f32 * scale).round() as u32).max(1);
+
+    let mut rgba_img = img.into_rgba8();
+    let src_image = fast_image_resize::images::Image::from_slice_u8(
+        orig_w,
+        orig_h,
+        rgba_img.as_mut(),
+        fast_image_resize::PixelType::U8x4,
+    )
+    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    let resized = fast_resize(
+        src_image,
+        new_w,
+        new_h,
+        fast_image_resize::FilterType::Lanczos3,
+    )?;
+    Ok(image::DynamicImage::ImageRgba8(resized))
+}
+
+/// Resize an HDR (Rgba32F) image to fit within max_width×max_height, preserving aspect ratio.
+///
+/// Uses `fast_image_resize` with `F32x4` pixel type for SIMD-accelerated bilinear interpolation
+/// directly on f32 data — no precision loss or format conversion overhead.
+/// Falls back to `image::imageops::resize` if the fast path fails.
+fn resize_for_gpu_hdr(
+    img: image::Rgba32FImage,
+    max_width: u32,
+    max_height: u32,
+) -> image::Rgba32FImage {
+    if max_width == 0 || max_height == 0 {
+        return img;
+    }
+    let (orig_w, orig_h) = (img.width(), img.height());
+    if orig_w <= max_width && orig_h <= max_height {
+        return img;
+    }
+    let scale_w = max_width as f32 / orig_w as f32;
+    let scale_h = max_height as f32 / orig_h as f32;
+    let scale = scale_w.min(scale_h);
+    let new_w = ((orig_w as f32 * scale).round() as u32).max(1);
+    let new_h = ((orig_h as f32 * scale).round() as u32).max(1);
+
+    let fallback =
+        || image::imageops::resize(&img, new_w, new_h, image::imageops::FilterType::Triangle);
+
+    // Cast the f32 pixel buffer directly to bytes — no conversion needed for F32x4.
+    let f32_bytes: &[u8] = bytemuck::cast_slice(img.as_raw());
+
+    let src = match fast_image_resize::images::ImageRef::new(
+        orig_w,
+        orig_h,
+        f32_bytes,
+        fast_image_resize::PixelType::F32x4,
+    ) {
+        Ok(s) => s,
+        Err(_) => return fallback(),
+    };
+
+    let mut dst =
+        fast_image_resize::images::Image::new(new_w, new_h, fast_image_resize::PixelType::F32x4);
+
+    let mut resizer = fast_image_resize::Resizer::new();
+    let opts = fast_image_resize::ResizeOptions::new().resize_alg(
+        fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Bilinear),
+    );
+    if resizer.resize(&src, &mut dst, &opts).is_err() {
+        return fallback();
+    }
+
+    let f32_pixels: Vec<f32> = bytemuck::cast_slice(dst.buffer()).to_vec();
+    image::Rgba32FImage::from_raw(new_w, new_h, f32_pixels).unwrap_or_else(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- mip_level_count() ---
+
+    #[test]
+    fn mip_level_count_1x1() {
+        assert_eq!(mip_level_count(1, 1), 1);
+    }
+
+    #[test]
+    fn mip_level_count_1024x1024() {
+        // ilog2(1024) = 10, so 11 levels
+        assert_eq!(mip_level_count(1024, 1024), 11);
+    }
+
+    #[test]
+    fn mip_level_count_non_square_uses_max_dim() {
+        // max dim = 1920, ilog2(1920) = 10, so 11 levels
+        assert_eq!(mip_level_count(1920, 1080), 11);
+    }
+
+    // --- linear_to_srgb() ---
+
+    #[test]
+    fn linear_to_srgb_zero_maps_to_zero() {
+        assert_eq!(linear_to_srgb(0.0), 0.0);
+    }
+
+    #[test]
+    fn linear_to_srgb_one_maps_to_one() {
+        assert!((linear_to_srgb(1.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_to_srgb_low_value_uses_linear_segment() {
+        // Values <= 0.003_130_8 use the linear c * 12.92 branch
+        let v = 0.001_f32;
+        assert!((linear_to_srgb(v) - v * 12.92).abs() < 1e-6);
+    }
+}

--- a/src/image_loader/exif.rs
+++ b/src/image_loader/exif.rs
@@ -1,0 +1,66 @@
+//! EXIF orientation handling and EXR metadata extraction.
+
+use camino::Utf8Path;
+
+/// Read the EXIF orientation tag from a reader without consuming the whole stream.
+pub(crate) fn read_exif_orientation<R: std::io::BufRead + std::io::Seek>(
+    reader: &mut R,
+) -> Option<u32> {
+    exif::Reader::new()
+        .read_from_container(reader)
+        .ok()?
+        .get_field(exif::Tag::Orientation, exif::In::PRIMARY)?
+        .value
+        .get_uint(0)
+}
+
+/// Apply a raw EXIF orientation value to an image.
+pub(crate) fn apply_orientation(
+    img: image::DynamicImage,
+    orientation: Option<u32>,
+) -> image::DynamicImage {
+    match orientation {
+        Some(2) => img.fliph(),
+        Some(3) => img.rotate180(),
+        Some(4) => img.flipv(),
+        Some(5) => img.rotate90().fliph(),
+        Some(6) => img.rotate90(),
+        Some(7) => img.rotate270().fliph(),
+        Some(8) => img.rotate270(),
+        _ => img,
+    }
+}
+
+/// Extract framerate from EXR metadata.
+/// Returns None if the file is not readable or lacks framesPerSecond attribute.
+pub(super) fn extract_exr_fps(path: &Utf8Path) -> Option<f32> {
+    use exr::prelude::*;
+
+    let reader = match read()
+        .no_deep_data()
+        .largest_resolution_level()
+        .all_channels()
+        .all_layers()
+        .all_attributes()
+        .non_parallel()
+        .from_file(path.as_std_path())
+    {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+
+    // Check standard framesPerSecond attribute
+    for layer in &reader.layer_data {
+        for (name, value) in &layer.attributes.other {
+            if name == "framesPerSecond" {
+                if let AttributeValue::F32(fps) = value {
+                    if *fps > 0.0 && fps.is_finite() {
+                        return Some(*fps);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/src/image_loader/mod.rs
+++ b/src/image_loader/mod.rs
@@ -1,19 +1,23 @@
 //! Async image loading with GPU texture management and rolling cache.
 
-use crate::error::{Result, SldshowError};
+mod decode;
+pub(crate) mod exif;
+mod scan;
+
+pub use scan::scan_image_paths;
+
 use camino::{Utf8Path, Utf8PathBuf};
-use image::GenericImageView;
 use log::{debug, error, info, warn};
-use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 use std::sync::mpsc::{Receiver, Sender, channel};
+
+pub(crate) use decode::fast_resize;
+pub(crate) use exif::{apply_orientation, read_exif_orientation};
+use decode::load_image_mips;
+use exif::extract_exr_fps;
 
 /// Maximum number of concurrent loading tasks
 const MAX_CONCURRENT_TASKS: usize = 4;
-
-/// Maximum directory recursion depth to prevent infinite loops
-const MAX_SCAN_DEPTH: usize = 128;
 
 pub struct LoadedTexture {
     #[allow(dead_code)] // Kept alive to prevent GPU texture deallocation
@@ -74,7 +78,11 @@ impl TextureManager {
         }
     }
 
-    pub fn scan_paths(&mut self, input_paths: &[Utf8PathBuf], scan_subfolders: bool) -> Result<()> {
+    pub fn scan_paths(
+        &mut self,
+        input_paths: &[Utf8PathBuf],
+        scan_subfolders: bool,
+    ) -> crate::error::Result<()> {
         let sorted_paths = scan_image_paths(input_paths, scan_subfolders)?;
         self.original_paths = sorted_paths.clone();
         self.paths = sorted_paths;
@@ -449,400 +457,6 @@ impl TextureManager {
     }
 }
 
-// Standalone functions
-
-/// Converts a linear light value to sRGB using the IEC 61966-2-1 piecewise transfer function.
-/// This is more accurate than the simple gamma 2.2 approximation, especially for near-black values.
-fn linear_to_srgb(c: f32) -> f32 {
-    if c <= 0.003_130_8 {
-        c * 12.92
-    } else {
-        1.055 * c.powf(1.0 / 2.4) - 0.055
-    }
-}
-
-// Helper to perform fast resizing using fast_image_resize
-pub(crate) fn fast_resize(
-    src_img: fast_image_resize::images::Image,
-    dst_width: u32,
-    dst_height: u32,
-    filter: fast_image_resize::FilterType,
-) -> anyhow::Result<image::RgbaImage> {
-    // Create destination image
-    let mut dst_img = fast_image_resize::images::Image::new(
-        dst_width,
-        dst_height,
-        fast_image_resize::PixelType::U8x4,
-    );
-
-    // Create resizer
-    let mut resizer = fast_image_resize::Resizer::new();
-    let resize_opts = fast_image_resize::ResizeOptions::new()
-        .resize_alg(fast_image_resize::ResizeAlg::Convolution(filter));
-
-    // Resize
-    resizer
-        .resize(&src_img, &mut dst_img, &resize_opts)
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-    // Convert back to image::RgbaImage
-    let buffer = dst_img.into_vec();
-    image::RgbaImage::from_raw(dst_width, dst_height, buffer)
-        .ok_or_else(|| anyhow::anyhow!("from_raw failed"))
-}
-
-fn load_image_mips(path: &Utf8Path, max_size: (u32, u32), is_hdr: bool) -> anyhow::Result<MipData> {
-    use std::fs::File;
-    use std::io::{BufReader, Seek, SeekFrom};
-
-    let file = File::open(path.as_std_path())
-        .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
-    let mut reader = BufReader::new(file);
-
-    // Read EXIF orientation before decoding so we open the file only once.
-    let orientation = read_exif_orientation(&mut reader);
-    reader
-        .seek(SeekFrom::Start(0))
-        .map_err(|e| anyhow::anyhow!("Failed to seek image: {}", e))?;
-
-    let img = image::ImageReader::new(&mut reader)
-        .with_guessed_format()
-        .map_err(|e| anyhow::anyhow!("Failed to guess image format: {}", e))?
-        .decode()
-        .map_err(|e| anyhow::anyhow!("Failed to open image: {}", e))?;
-
-    let is_exr = path.extension().unwrap_or("").eq_ignore_ascii_case("exr");
-
-    if is_hdr && is_exr {
-        // HDR path: keep linear float data as Rgba32F, skip sRGB conversion.
-        // GPU upload will convert f32 → f16 for Rgba16Float texture.
-        let rgba32f = img.into_rgba32f();
-        let img = apply_orientation(image::DynamicImage::ImageRgba32F(rgba32f), orientation);
-        let base = resize_for_gpu_hdr(img.into_rgba32f(), max_size.0, max_size.1);
-
-        // Generate mip chain using image::imageops (fast_image_resize is U8 only)
-        let mip_count = mip_level_count(base.width(), base.height());
-        let mut mips: Vec<image::Rgba32FImage> = Vec::with_capacity(mip_count as usize);
-        mips.push(base);
-
-        for _ in 1..mip_count {
-            let prev = mips.last().expect("mip chain is non-empty");
-            let new_w = (prev.width() / 2).max(1);
-            let new_h = (prev.height() / 2).max(1);
-            let resized =
-                image::imageops::resize(prev, new_w, new_h, image::imageops::FilterType::Triangle);
-            mips.push(resized);
-        }
-
-        Ok(MipData::Hdr(mips))
-    } else {
-        // SDR path: existing behavior — tonemap EXR to sRGB, upload as Rgba8UnormSrgb.
-        let mut img = img;
-        if is_exr {
-            // Apply the IEC 61966-2-1 piecewise sRGB transfer function per channel
-            let mut rgba32f = img.into_rgba32f();
-            for pixel in rgba32f.pixels_mut() {
-                pixel[0] = linear_to_srgb(pixel[0].max(0.0));
-                pixel[1] = linear_to_srgb(pixel[1].max(0.0));
-                pixel[2] = linear_to_srgb(pixel[2].max(0.0));
-                // Alpha remains linear
-            }
-            img = image::DynamicImage::ImageRgba32F(rgba32f);
-        }
-
-        let img = apply_orientation(img, orientation);
-        let base = resize_for_gpu(img, max_size.0, max_size.1)?.into_rgba8();
-
-        // Generate mipmap chain on CPU
-        let mip_count = mip_level_count(base.width(), base.height());
-        let mut mips = Vec::with_capacity(mip_count as usize);
-        mips.push(base);
-
-        for _ in 1..mip_count {
-            let prev = mips
-                .last()
-                .ok_or_else(|| anyhow::anyhow!("mip chain is empty"))?;
-            let new_w = (prev.width() / 2).max(1);
-            let new_h = (prev.height() / 2).max(1);
-
-            let mut prev_clone = prev.clone();
-
-            // Fast image resize wrapper creation
-            let src_image = fast_image_resize::images::Image::from_slice_u8(
-                prev.width(),
-                prev.height(),
-                prev_clone.as_mut(),
-                fast_image_resize::PixelType::U8x4,
-            )
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-            let resized = fast_resize(
-                src_image,
-                new_w,
-                new_h,
-                fast_image_resize::FilterType::Bilinear,
-            )?;
-            mips.push(resized);
-        }
-
-        Ok(MipData::Sdr(mips))
-    }
-}
-
-fn mip_level_count(width: u32, height: u32) -> u32 {
-    let max_dim = width.max(height).max(1);
-    max_dim.ilog2() + 1
-}
-
-/// Read the EXIF orientation tag from a reader without consuming the whole stream.
-pub(crate) fn read_exif_orientation<R: std::io::BufRead + std::io::Seek>(
-    reader: &mut R,
-) -> Option<u32> {
-    exif::Reader::new()
-        .read_from_container(reader)
-        .ok()?
-        .get_field(exif::Tag::Orientation, exif::In::PRIMARY)?
-        .value
-        .get_uint(0)
-}
-
-/// Apply a raw EXIF orientation value to an image.
-pub(crate) fn apply_orientation(
-    img: image::DynamicImage,
-    orientation: Option<u32>,
-) -> image::DynamicImage {
-    match orientation {
-        Some(2) => img.fliph(),
-        Some(3) => img.rotate180(),
-        Some(4) => img.flipv(),
-        Some(5) => img.rotate90().fliph(),
-        Some(6) => img.rotate90(),
-        Some(7) => img.rotate270().fliph(),
-        Some(8) => img.rotate270(),
-        _ => img,
-    }
-}
-
-/// Extract framerate from EXR metadata.
-/// Returns None if the file is not readable or lacks framesPerSecond attribute.
-fn extract_exr_fps(path: &Utf8Path) -> Option<f32> {
-    use exr::prelude::*;
-
-    let reader = match read()
-        .no_deep_data()
-        .largest_resolution_level()
-        .all_channels()
-        .all_layers()
-        .all_attributes()
-        .non_parallel()
-        .from_file(path.as_std_path())
-    {
-        Ok(r) => r,
-        Err(_) => return None,
-    };
-
-    // Check standard framesPerSecond attribute
-    for layer in &reader.layer_data {
-        for (name, value) in &layer.attributes.other {
-            if name == "framesPerSecond" {
-                if let AttributeValue::F32(fps) = value {
-                    if *fps > 0.0 && fps.is_finite() {
-                        return Some(*fps);
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-fn resize_for_gpu(
-    img: image::DynamicImage,
-    max_width: u32,
-    max_height: u32,
-) -> anyhow::Result<image::DynamicImage> {
-    // [0, 0] means "no limit" — upload at full resolution
-    if max_width == 0 || max_height == 0 {
-        return Ok(img);
-    }
-    let (orig_w, orig_h) = img.dimensions();
-    if orig_w <= max_width && orig_h <= max_height {
-        return Ok(img);
-    }
-    let scale_w = max_width as f32 / orig_w as f32;
-    let scale_h = max_height as f32 / orig_h as f32;
-    let scale = scale_w.min(scale_h);
-    let new_w = ((orig_w as f32 * scale).round() as u32).max(1);
-    let new_h = ((orig_h as f32 * scale).round() as u32).max(1);
-
-    let mut rgba_img = img.into_rgba8();
-    let src_image = fast_image_resize::images::Image::from_slice_u8(
-        orig_w,
-        orig_h,
-        rgba_img.as_mut(),
-        fast_image_resize::PixelType::U8x4,
-    )
-    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-    let resized = fast_resize(
-        src_image,
-        new_w,
-        new_h,
-        fast_image_resize::FilterType::Lanczos3,
-    )?;
-    Ok(image::DynamicImage::ImageRgba8(resized))
-}
-
-/// Resize an HDR (Rgba32F) image to fit within max_width×max_height, preserving aspect ratio.
-///
-/// Uses `fast_image_resize` with `F32x4` pixel type for SIMD-accelerated bilinear interpolation
-/// directly on f32 data — no precision loss or format conversion overhead.
-/// Falls back to `image::imageops::resize` if the fast path fails.
-fn resize_for_gpu_hdr(
-    img: image::Rgba32FImage,
-    max_width: u32,
-    max_height: u32,
-) -> image::Rgba32FImage {
-    if max_width == 0 || max_height == 0 {
-        return img;
-    }
-    let (orig_w, orig_h) = (img.width(), img.height());
-    if orig_w <= max_width && orig_h <= max_height {
-        return img;
-    }
-    let scale_w = max_width as f32 / orig_w as f32;
-    let scale_h = max_height as f32 / orig_h as f32;
-    let scale = scale_w.min(scale_h);
-    let new_w = ((orig_w as f32 * scale).round() as u32).max(1);
-    let new_h = ((orig_h as f32 * scale).round() as u32).max(1);
-
-    let fallback =
-        || image::imageops::resize(&img, new_w, new_h, image::imageops::FilterType::Triangle);
-
-    // Cast the f32 pixel buffer directly to bytes — no conversion needed for F32x4.
-    let f32_bytes: &[u8] = bytemuck::cast_slice(img.as_raw());
-
-    let src = match fast_image_resize::images::ImageRef::new(
-        orig_w,
-        orig_h,
-        f32_bytes,
-        fast_image_resize::PixelType::F32x4,
-    ) {
-        Ok(s) => s,
-        Err(_) => return fallback(),
-    };
-
-    let mut dst =
-        fast_image_resize::images::Image::new(new_w, new_h, fast_image_resize::PixelType::F32x4);
-
-    let mut resizer = fast_image_resize::Resizer::new();
-    let opts = fast_image_resize::ResizeOptions::new().resize_alg(
-        fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Bilinear),
-    );
-    if resizer.resize(&src, &mut dst, &opts).is_err() {
-        return fallback();
-    }
-
-    let f32_pixels: Vec<f32> = bytemuck::cast_slice(dst.buffer()).to_vec();
-    image::Rgba32FImage::from_raw(new_w, new_h, f32_pixels).unwrap_or_else(fallback)
-}
-
-pub fn scan_image_paths(
-    input_paths: &[Utf8PathBuf],
-    scan_subfolders: bool,
-) -> Result<Vec<Utf8PathBuf>> {
-    let mut paths: Vec<Utf8PathBuf> = input_paths
-        .par_iter()
-        .flat_map_iter(|path| {
-            let std_path = path.as_std_path();
-            if std_path.is_file() {
-                if is_supported_image(std_path) {
-                    vec![path.clone()].into_iter()
-                } else {
-                    vec![].into_iter()
-                }
-            } else if std_path.is_dir() {
-                match scan_directory_recursive_parallel(std_path, scan_subfolders, 0) {
-                    Ok(dir_paths) => dir_paths.into_iter(),
-                    Err(e) => {
-                        warn!("Failed to scan directory {}: {}", path, e);
-                        vec![].into_iter()
-                    }
-                }
-            } else {
-                vec![].into_iter()
-            }
-        })
-        .collect();
-
-    paths.sort_by(|a, b| alphanumeric_sort::compare_str(a.as_str(), b.as_str()));
-
-    if paths.is_empty() {
-        return Err(SldshowError::NoImagesFound {
-            paths: input_paths.to_vec(),
-        });
-    }
-
-    Ok(paths)
-}
-
-fn scan_directory_recursive_parallel(
-    dir: &Path,
-    recursive: bool,
-    depth: usize,
-) -> Result<Vec<Utf8PathBuf>> {
-    if depth >= MAX_SCAN_DEPTH {
-        warn!(
-            "Maximum scan depth ({}) reached at: {}",
-            MAX_SCAN_DEPTH,
-            dir.display()
-        );
-        return Ok(Vec::new());
-    }
-
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(e) => {
-            warn!("Failed to read directory {}: {}", dir.display(), e);
-            return Ok(Vec::new());
-        }
-    };
-
-    let paths: Vec<Utf8PathBuf> = entries
-        .flatten()
-        .par_bridge()
-        .flat_map_iter(|entry| {
-            let path = entry.path();
-            if path.is_file() && is_supported_image(&path) {
-                match Utf8PathBuf::try_from(path.clone()) {
-                    Ok(utf8_path) => vec![utf8_path].into_iter(),
-                    Err(_) => {
-                        warn!("skipping non-UTF-8 path: {:?}", path);
-                        vec![].into_iter()
-                    }
-                }
-            } else if path.is_dir() && recursive {
-                match scan_directory_recursive_parallel(&path, recursive, depth + 1) {
-                    Ok(subdir_paths) => subdir_paths.into_iter(),
-                    Err(e) => {
-                        warn!("failed to scan directory {:?}: {}", path, e);
-                        vec![].into_iter()
-                    }
-                }
-            } else {
-                vec![].into_iter()
-            }
-        })
-        .collect();
-
-    Ok(paths)
-}
-
-fn is_supported_image(path: &Path) -> bool {
-    image::ImageFormat::from_path(path).is_ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -959,43 +573,5 @@ mod tests {
         mgr.append_paths(vec![Utf8PathBuf::from("a.jpg"), Utf8PathBuf::from("b.jpg")]);
         assert_eq!(mgr.paths.len(), 2);
         assert_eq!(mgr.current_index, 0);
-    }
-
-    // --- mip_level_count() ---
-
-    #[test]
-    fn mip_level_count_1x1() {
-        assert_eq!(mip_level_count(1, 1), 1);
-    }
-
-    #[test]
-    fn mip_level_count_1024x1024() {
-        // ilog2(1024) = 10, so 11 levels
-        assert_eq!(mip_level_count(1024, 1024), 11);
-    }
-
-    #[test]
-    fn mip_level_count_non_square_uses_max_dim() {
-        // max dim = 1920, ilog2(1920) = 10, so 11 levels
-        assert_eq!(mip_level_count(1920, 1080), 11);
-    }
-
-    // --- linear_to_srgb() ---
-
-    #[test]
-    fn linear_to_srgb_zero_maps_to_zero() {
-        assert_eq!(linear_to_srgb(0.0), 0.0);
-    }
-
-    #[test]
-    fn linear_to_srgb_one_maps_to_one() {
-        assert!((linear_to_srgb(1.0) - 1.0).abs() < 1e-5);
-    }
-
-    #[test]
-    fn linear_to_srgb_low_value_uses_linear_segment() {
-        // Values <= 0.003_130_8 use the linear c * 12.92 branch
-        let v = 0.001_f32;
-        assert!((linear_to_srgb(v) - v * 12.92).abs() < 1e-6);
     }
 }

--- a/src/image_loader/scan.rs
+++ b/src/image_loader/scan.rs
@@ -1,0 +1,105 @@
+//! Image path scanning and directory traversal.
+
+use crate::error::{Result, SldshowError};
+use camino::Utf8PathBuf;
+use log::warn;
+use rayon::prelude::*;
+use std::path::Path;
+
+/// Maximum directory recursion depth to prevent infinite loops
+const MAX_SCAN_DEPTH: usize = 128;
+
+pub fn scan_image_paths(
+    input_paths: &[Utf8PathBuf],
+    scan_subfolders: bool,
+) -> Result<Vec<Utf8PathBuf>> {
+    let mut paths: Vec<Utf8PathBuf> = input_paths
+        .par_iter()
+        .flat_map_iter(|path| {
+            let std_path = path.as_std_path();
+            if std_path.is_file() {
+                if is_supported_image(std_path) {
+                    vec![path.clone()].into_iter()
+                } else {
+                    vec![].into_iter()
+                }
+            } else if std_path.is_dir() {
+                match scan_directory_recursive_parallel(std_path, scan_subfolders, 0) {
+                    Ok(dir_paths) => dir_paths.into_iter(),
+                    Err(e) => {
+                        warn!("Failed to scan directory {}: {}", path, e);
+                        vec![].into_iter()
+                    }
+                }
+            } else {
+                vec![].into_iter()
+            }
+        })
+        .collect();
+
+    paths.sort_by(|a, b| alphanumeric_sort::compare_str(a.as_str(), b.as_str()));
+
+    if paths.is_empty() {
+        return Err(SldshowError::NoImagesFound {
+            paths: input_paths.to_vec(),
+        });
+    }
+
+    Ok(paths)
+}
+
+fn scan_directory_recursive_parallel(
+    dir: &Path,
+    recursive: bool,
+    depth: usize,
+) -> Result<Vec<Utf8PathBuf>> {
+    if depth >= MAX_SCAN_DEPTH {
+        warn!(
+            "Maximum scan depth ({}) reached at: {}",
+            MAX_SCAN_DEPTH,
+            dir.display()
+        );
+        return Ok(Vec::new());
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!("Failed to read directory {}: {}", dir.display(), e);
+            return Ok(Vec::new());
+        }
+    };
+
+    let paths: Vec<Utf8PathBuf> = entries
+        .flatten()
+        .par_bridge()
+        .flat_map_iter(|entry| {
+            let path = entry.path();
+            if path.is_file() && is_supported_image(&path) {
+                match Utf8PathBuf::try_from(path.clone()) {
+                    Ok(utf8_path) => vec![utf8_path].into_iter(),
+                    Err(_) => {
+                        warn!("skipping non-UTF-8 path: {:?}", path);
+                        vec![].into_iter()
+                    }
+                }
+            } else if path.is_dir() && recursive {
+                match scan_directory_recursive_parallel(&path, recursive, depth + 1) {
+                    Ok(subdir_paths) => subdir_paths.into_iter(),
+                    Err(e) => {
+                        warn!("failed to scan directory {:?}: {}", path, e);
+                        vec![].into_iter()
+                    }
+                }
+            } else {
+                vec![].into_iter()
+            }
+        })
+        .collect();
+
+    Ok(paths)
+}
+
+fn is_supported_image(path: &Path) -> bool {
+    image::ImageFormat::from_path(path).is_ok()
+}


### PR DESCRIPTION
Closes #342

## Overview
Split `image_loader.rs` (1001 lines) into a `image_loader/` module directory with focused submodules.

## Changes
- `mod.rs` — TextureManager, types, GPU upload, cache management, tests (575 lines)
- `decode.rs` — Image decoding, mipmap generation, resize helpers, tests (260 lines)
- `exif.rs` — EXIF orientation + EXR fps extraction (65 lines)
- `scan.rs` — Path scanning and directory traversal (100 lines)

## Testing
- [x] All quality gate checks passed (cargo fmt, clippy, test, build)
- [x] Manual testing recommended
