### PR TITLE
fix: prevent egui panel drag from moving main window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1467,12 +1467,12 @@ impl ApplicationHandler for ApplicationState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use winit::event::{ElementState, MouseButton, MouseScrollDelta};
+    use winit::event::{DeviceId, ElementState, MouseButton, MouseScrollDelta};
 
     #[test]
     fn is_pointer_event_cursor_moved() {
         let event = WindowEvent::CursorMoved {
-            device_id: unsafe { std::mem::zeroed() },
+            device_id: DeviceId::dummy(),
             position: winit::dpi::PhysicalPosition::new(10.0, 20.0),
         };
         assert!(is_pointer_event(&event));
@@ -1481,7 +1481,7 @@ mod tests {
     #[test]
     fn is_pointer_event_mouse_input() {
         let event = WindowEvent::MouseInput {
-            device_id: unsafe { std::mem::zeroed() },
+            device_id: DeviceId::dummy(),
             state: ElementState::Pressed,
             button: MouseButton::Left,
         };
@@ -1491,7 +1491,7 @@ mod tests {
     #[test]
     fn is_pointer_event_mouse_wheel() {
         let event = WindowEvent::MouseWheel {
-            device_id: unsafe { std::mem::zeroed() },
+            device_id: DeviceId::dummy(),
             delta: MouseScrollDelta::LineDelta(0.0, 1.0),
             phase: winit::event::TouchPhase::Moved,
         };

--- a/src/input.rs
+++ b/src/input.rs
@@ -124,6 +124,11 @@ impl InputHandler {
         self.drag_start_cursor = None;
         self.drag_start_screen = None;
         self.is_dragging = false;
+        // Neutralize click-related state so a pending mouse release
+        // cannot trigger navigation or double-click behavior after egui
+        // has taken pointer input.
+        self.ignore_next_release = true;
+        self.last_click_time = None;
     }
 
     /// Handles a window event and returns (consumed, optional_action).
@@ -464,16 +469,21 @@ mod tests {
     fn cancel_drag_clears_all_drag_state() {
         let mut handler = InputHandler::new();
 
-        // Simulate an active drag
+        // Simulate an active drag with pending click state
         handler.drag_start_cursor = Some(PhysicalPosition::new(100.0, 200.0));
         handler.drag_start_screen = Some(PhysicalPosition::new(150.0, 250.0));
         handler.is_dragging = true;
+        handler.last_click_time = Some(Instant::now());
+        handler.ignore_next_release = false;
 
         handler.cancel_drag();
 
         assert!(handler.drag_start_cursor.is_none());
         assert!(handler.drag_start_screen.is_none());
         assert!(!handler.is_dragging);
+        // Click state is neutralized to prevent ghost navigation
+        assert!(handler.ignore_next_release);
+        assert!(handler.last_click_time.is_none());
     }
 
     #[test]
@@ -486,6 +496,8 @@ mod tests {
         assert!(handler.drag_start_cursor.is_none());
         assert!(handler.drag_start_screen.is_none());
         assert!(!handler.is_dragging);
+        assert!(handler.ignore_next_release);
+        assert!(handler.last_click_time.is_none());
     }
 
     #[test]

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -319,8 +319,13 @@ impl EguiOverlay {
         self.osc.check_autohide();
     }
 
-    /// Returns true when egui is currently interested in pointer input
+    /// Returns true when egui is interested in pointer input
     /// (e.g. hovering over a panel or actively dragging a widget).
+    ///
+    /// Note: this is typically queried from `window_event()` before the next
+    /// `begin_frame()`/`build_ui()` pass, so it effectively reflects egui's
+    /// *previous-frame* state due to the known 1-frame delay in egui's input
+    /// processing.
     pub fn wants_pointer_input(&self) -> bool {
         self.context.wants_pointer_input()
     }


### PR DESCRIPTION
Closes #214

## Overview

When the user drags a settings panel header, the main window was also moving because pointer events were reaching `InputHandler` even when egui had already claimed ownership of the pointer.

## Changes

- **`src/overlay/mod.rs`**: Added `wants_pointer_input()` accessor on `EguiOverlay` that delegates to `egui::Context::wants_pointer_input()`.
- **`src/input.rs`**: Added `cancel_drag()` method on `InputHandler` to clear stale drag state when egui claims the pointer.
- **`src/app.rs`**: Applied the imgui `WantCaptureMouse` pattern in `window_event()`:
  - `CursorMoved` side effects (OSC activity update, cursor visibility restore) now run unconditionally so they work even when egui has the pointer.
  - A guard checks `wants_pointer_input()` before forwarding pointer events (`CursorMoved`, `MouseInput`, `MouseWheel`) to `InputHandler`.
  - Any in-progress drag is cancelled when egui claims the pointer, preventing stale drag state from causing window movement on the next unguarded event.

## Notes

- This follows the same pattern used by Dear ImGui's `WantCaptureMouse` flag.
- There is an accepted 1-frame delay inherent to egui's input model: egui reports `wants_pointer_input()` based on the *previous* frame's hover/interaction state. On the very first frame where the cursor enters a panel, one pointer event may slip through before egui reports interest. This is a known egui limitation and is not meaningfully observable in practice.
- `cancel_drag()` is called proactively during the guard rather than on release to prevent a "release outside panel" scenario from triggering an unintended click-to-next-image action.

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (21/21)
- [x] `cargo build --release` succeeded
- [x] Manual: open settings panel, drag its title bar — main window should not move
- [x] Manual: drag main window outside any panel — should still work normally
- [x] Manual: cursor auto-hide should still trigger correctly when egui is active
