### PR TITLE
chore: upgrade windows crate from v0.58 to v0.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ name = "gpu_transition_invariants"
 path = "tests/gpu/transition_invariants.rs"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
     "Win32_System_Power",
     "Win32_System_Ole",
     "Win32_Foundation",


### PR DESCRIPTION
Closes #352

## Overview
Upgrades the `windows` crate from v0.58 to v0.62.2. All four feature flags used by the project (`Win32_System_Power`, `Win32_System_Ole`, `Win32_Foundation`, `Win32_UI_Shell`) remain present and unchanged in v0.62, so no source code changes are required.

## Changes
- `Cargo.toml`: bump `windows` version from `"0.58"` to `"0.62"`

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed (no warnings)
- [x] `cargo test --all-features` passed (133 tests: 112 unit + 21 GPU)
- [x] `cargo build --release` succeeded
- [x] Manual visual test recommended: `cargo run --release -- example.sldshow`

## Notes
No API surface changes were needed. The `HWND`, `DragQueryFileW`, `SetThreadExecutionState`, and related Win32 bindings are all stable across this version range.
