### PR TITLE
chore: upgrade rand, validator, pollster, toml to latest major versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/ugai/sldshow2"
 # Graphics & Windowing
 winit = "0.30"
 wgpu = "27"
-pollster = "0.3"
+pollster = "0.4"
 bytemuck = { version = "1.16", features = ["derive"] }
 env_logger = "0.11"
 log = "0.4"
@@ -25,7 +25,7 @@ egui-winit = "0.33"
 
 # Configuration
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.8"
+toml = "1.0"
 
 # Image processing
 image = { version = "0.25", features = ["exr"] }
@@ -33,7 +33,7 @@ exr = "1.72"
 
 # Utilities
 anyhow = "1.0"
-rand = "0.9"
+rand = "0.10"
 alphanumeric-sort = "1.5"
 dirs = "5.0"
 
@@ -41,7 +41,7 @@ dirs = "5.0"
 thiserror = "2.0"
 
 # Validation
-validator = { version = "0.19", features = ["derive"] }
+validator = { version = "0.20", features = ["derive"] }
 
 # Parallel computation
 rayon = "1.10"

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -202,7 +202,7 @@ impl TransitionPipeline {
 
     /// Pick a random transition mode from available effects
     pub fn random_mode() -> TransitionMode {
-        use rand::Rng;
+        use rand::RngExt;
         let mut rng = rand::rng();
         // SAFETY: TRANSITION_MODE_COUNT is 20, so range is 0..20 i.e. 0..=19 which is valid
         TransitionMode::try_from(rng.random_range(0..TRANSITION_MODE_COUNT))


### PR DESCRIPTION
Closes #353

## Overview

Upgrades four dependencies to their latest major versions: rand 0.9→0.10, validator 0.19→0.20, pollster 0.3→0.4, and toml 0.8→1.0.

## Changes

- `Cargo.toml`: bump `rand` to 0.10, `validator` to 0.20, `pollster` to 0.4, `toml` to 1.0
- `src/transition.rs`: update import from `rand::Rng` to `rand::RngExt` — `random_range` moved to the `RngExt` extension trait in rand 0.10
- No other API changes were needed for validator, pollster, or toml upgrades

## Testing

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo check` compiled cleanly (all four new versions resolved correctly per Cargo.lock)
- [x] `cargo test` and `cargo build --release` blocked by host disk space constraints; all compilation errors were resolved before disk filled
