### PR TITLE
fix: prioritize current_index in texture preload queue

### DIFF
--- a/src/image_loader/mod.rs
+++ b/src/image_loader/mod.rs
@@ -334,7 +334,17 @@ impl TextureManager {
         self.loading_tasks
             .retain(|idx, _| needed_indices.contains(idx));
 
-        for idx in needed_indices {
+        // Iterate in priority order: current first, then alternating next/prev.
+        // This ensures the most important textures get loading slots first,
+        // unlike HashSet iteration which has non-deterministic order.
+        let priority_order =
+            std::iter::once(self.current_index).chain((1..=extent).flat_map(|i| {
+                let next = (self.current_index + i) % len;
+                let prev = (self.current_index + len - i) % len;
+                [next, prev]
+            }));
+
+        for idx in priority_order {
             if !self.textures.contains_key(&idx)
                 && !self.errors.contains_key(&idx)
                 && !self.loading_tasks.contains_key(&idx)


### PR DESCRIPTION
Closes #358

## Overview
The texture preload loop iterated over a `HashSet`, making the order non-deterministic. When `MAX_CONCURRENT_TASKS` slots filled before `current_index` was reached, the currently displayed image could experience a visible loading delay.

## Changes
- Replaced the `HashSet` iteration in the loading-task enqueue loop with a priority-ordered iterator: `current_index` first, then alternating next/previous neighbors
- The `HashSet` is still used for cache retention (`retain`) where order doesn't matter

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (all 133 tests)
- [x] Manual testing: open a large playlist, jump to a distant image, verify it loads immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
