### PR TITLE
refactor: replace AdjustTimer sentinel value with explicit fields

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -479,15 +479,16 @@ impl ApplicationState {
             | InputAction::ToggleAlwaysOnTop
             | InputAction::ResizeWindow { .. }
             | InputAction::SetWindowPosition { .. } => self.handle_window_action(action),
-            InputAction::AdjustTimer(mut delta) => {
-                // Recalculate delta for non-Shift keys
-                if delta.abs() == 1.0 {
-                    delta = if delta > 0.0 {
-                        self.timer_step(true)
-                    } else {
-                        -self.timer_step(false)
-                    };
-                }
+            InputAction::AdjustTimer {
+                increase,
+                large_step,
+            } => {
+                let delta = if large_step {
+                    if increase { 60.0 } else { -60.0 }
+                } else {
+                    let step = self.timer_step(increase);
+                    if increase { step } else { -step }
+                };
                 self.adjust_timer(delta);
             }
             InputAction::ResetTimer => self.reset_timer(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,7 +27,10 @@ pub enum InputAction {
     SetFullscreen(bool),
     ToggleDecorations,
     ToggleAlwaysOnTop,
-    AdjustTimer(f32),
+    AdjustTimer {
+        increase: bool,
+        large_step: bool,
+    },
     ResetTimer,
     Screenshot,
     ColorAdjust {
@@ -365,23 +368,14 @@ impl InputHandler {
             PhysicalKey::Code(KeyCode::KeyF) => Some(InputAction::ToggleFullscreen),
             PhysicalKey::Code(KeyCode::KeyD) => Some(InputAction::ToggleDecorations),
             PhysicalKey::Code(KeyCode::KeyT) => Some(InputAction::ToggleAlwaysOnTop),
-            PhysicalKey::Code(KeyCode::BracketLeft) => {
-                let delta = if modifiers.shift_key() {
-                    -60.0
-                } else {
-                    // Timer step calculation deferred to ApplicationState
-                    -1.0 // Placeholder, will be recalculated
-                };
-                Some(InputAction::AdjustTimer(delta))
-            }
-            PhysicalKey::Code(KeyCode::BracketRight) => {
-                let delta = if modifiers.shift_key() {
-                    60.0
-                } else {
-                    1.0 // Placeholder
-                };
-                Some(InputAction::AdjustTimer(delta))
-            }
+            PhysicalKey::Code(KeyCode::BracketLeft) => Some(InputAction::AdjustTimer {
+                increase: false,
+                large_step: modifiers.shift_key(),
+            }),
+            PhysicalKey::Code(KeyCode::BracketRight) => Some(InputAction::AdjustTimer {
+                increase: true,
+                large_step: modifiers.shift_key(),
+            }),
             PhysicalKey::Code(KeyCode::Backspace) => {
                 if modifiers.shift_key() {
                     Some(InputAction::ResetColorAdjustments)


### PR DESCRIPTION
Closes #359

## Overview
The `InputAction::AdjustTimer(f32)` variant used `±1.0` as invisible sentinels meaning "recalculate the real delta in app.rs". This was fragile (floating-point equality) and unclear at both call sites. Replaced with named fields that make the intent explicit.

## Changes
- Changed `AdjustTimer(f32)` to `AdjustTimer { increase: bool, large_step: bool }` in `InputAction` enum
- Updated `input.rs` to emit the new variant with explicit fields instead of sentinel values
- Updated `app.rs` match arm to compute the delta from the fields, removing the `delta.abs() == 1.0` check

## Testing
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --all-features -- -D warnings` passed
- [x] `cargo test --all-features` passed (all 133 tests)
- [x] Manual testing: `[` / `]` keys for timer adjust, Shift+`[` / Shift+`]` for ±60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
