### PR TITLE
fix: warn when ~/.sldshow is ignored due to non-UTF-8 home path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{Result, SldshowError};
 use camino::{Utf8Path, Utf8PathBuf};
+use log::warn;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use validator::Validate;
 
@@ -351,10 +352,16 @@ impl Config {
 
         if let Some(home) = dirs::home_dir() {
             let home_config = home.join(".sldshow");
-            if home_config.exists()
-                && let Ok(utf8_path) = Utf8PathBuf::try_from(home_config)
-            {
-                return Self::load(&utf8_path);
+            if home_config.exists() {
+                match Utf8PathBuf::try_from(home_config) {
+                    Ok(utf8_path) => return Self::load(&utf8_path),
+                    Err(e) => {
+                        warn!(
+                            "found ~/.sldshow but home path is not UTF-8; ignoring config: {}",
+                            e.into_path_buf().display()
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- When `~/.sldshow` exists but the home directory path is not valid UTF-8, the config was previously silently ignored.
- Now a `warn!` log message is emitted: `"found ~/.sldshow but home path is not UTF-8; ignoring config: <path>"`, allowing users to diagnose why their config file was skipped.
- The silent-ignore behavior for the file-not-exist branch is unchanged.

## Notes

A unit test for the non-UTF-8 path case was not added. Injecting a fake non-UTF-8 home path requires either mocking `dirs::home_dir()` (not straightforward without additional abstraction) or platform-specific test fixtures. The behavioral change is simple enough that manual inspection is sufficient.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --lib config` — all 20 tests pass
- [x] Code reviewed: only `src/config.rs` changed

Closes #402
