### PR TITLE
refactor: log SetThreadExecutionState failures for screensaver guard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,12 @@ impl Drop for ScreenSaverGuard {
     fn drop(&mut self) {
         unsafe {
             use windows::Win32::System::Power::{ES_CONTINUOUS, SetThreadExecutionState};
-            SetThreadExecutionState(ES_CONTINUOUS);
+            let prev = SetThreadExecutionState(ES_CONTINUOUS);
+            if prev.0 == 0 {
+                warn!(
+                    "SetThreadExecutionState restore returned 0; system may remain in ES_CONTINUOUS until reboot"
+                );
+            }
         }
     }
 }
@@ -61,7 +66,11 @@ fn main() -> Result<()> {
                 ES_CONTINUOUS, ES_DISPLAY_REQUIRED, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
             };
             // Prevents sleep and screen saver
-            SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            let prev =
+                SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            if prev.0 == 0 {
+                warn!("SetThreadExecutionState failed; screensaver may activate during slideshow");
+            }
         }
         ScreenSaverGuard
     };


### PR DESCRIPTION
## Summary

- Capture the `EXECUTION_STATE` return value from `SetThreadExecutionState` on both the initial set (in `main`) and the restore (in `ScreenSaverGuard::drop`).
- Emit a `warn!` log message if the return value is `0` (failure), providing runtime visibility into screensaver-prevention failures.

## Test plan

- [ ] `cargo build` compiles without errors or warnings
- [ ] `cargo clippy -- -D warnings` passes clean
- [ ] `cargo test` passes (21 tests, 0 failed)
- [ ] No functional change: screensaver guard behavior is identical; only logging is added on failure

Closes #404
