### PR TITLE
fix: improve directory scan robustness (I/O errors + symlink cycles)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fax"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3206,7 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
  "validator",
@@ -3349,6 +3356,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ egui-phosphor = "0.12"
 fast_image_resize = "6.0.0"
 half = "2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [[test]]
 name = "gpu_transition_invariants"
 path = "tests/gpu/transition_invariants.rs"

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,13 @@ pub enum SldshowError {
     #[error("No images found in paths: {}", paths.iter().map(|p| p.as_str()).collect::<Vec<_>>().join(", "))]
     NoImagesFound { paths: Vec<Utf8PathBuf> },
 
+    #[error("Directory scan failed for {path}: {source}")]
+    ScanFailed {
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("Failed to load config from {path}: {source}")]
     ConfigLoadError {
         path: Utf8PathBuf,

--- a/src/image_loader/scan.rs
+++ b/src/image_loader/scan.rs
@@ -5,6 +5,7 @@ use camino::Utf8PathBuf;
 use log::warn;
 use rayon::prelude::*;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 /// Maximum directory recursion depth to prevent infinite loops
 const MAX_SCAN_DEPTH: usize = 128;
@@ -13,6 +14,9 @@ pub fn scan_image_paths(
     input_paths: &[Utf8PathBuf],
     scan_subfolders: bool,
 ) -> Result<Vec<Utf8PathBuf>> {
+    // Collect fatal I/O errors so we can surface one if no images are found.
+    let errors: Arc<Mutex<Vec<(Utf8PathBuf, std::io::Error)>>> = Arc::new(Mutex::new(Vec::new()));
+
     let mut paths: Vec<Utf8PathBuf> = input_paths
         .par_iter()
         .flat_map_iter(|path| {
@@ -24,7 +28,7 @@ pub fn scan_image_paths(
                     vec![].into_iter()
                 }
             } else if std_path.is_dir() {
-                match scan_directory_recursive_parallel(std_path, scan_subfolders, 0) {
+                match scan_directory_recursive_parallel(std_path, scan_subfolders, 0, &errors) {
                     Ok(dir_paths) => dir_paths.into_iter(),
                     Err(e) => {
                         warn!("Failed to scan directory {}: {}", path, e);
@@ -40,6 +44,11 @@ pub fn scan_image_paths(
     paths.sort_by(|a, b| alphanumeric_sort::compare_str(a.as_str(), b.as_str()));
 
     if paths.is_empty() {
+        // Surface the first fatal I/O error rather than a generic NoImagesFound.
+        let mut guard = errors.lock().unwrap();
+        if let Some((path, source)) = guard.drain(..).next() {
+            return Err(SldshowError::ScanFailed { path, source });
+        }
         return Err(SldshowError::NoImagesFound {
             paths: input_paths.to_vec(),
         });
@@ -52,6 +61,7 @@ fn scan_directory_recursive_parallel(
     dir: &Path,
     recursive: bool,
     depth: usize,
+    errors: &Arc<Mutex<Vec<(Utf8PathBuf, std::io::Error)>>>,
 ) -> Result<Vec<Utf8PathBuf>> {
     if depth >= MAX_SCAN_DEPTH {
         warn!(
@@ -62,20 +72,45 @@ fn scan_directory_recursive_parallel(
         return Ok(Vec::new());
     }
 
-    let entries = match std::fs::read_dir(dir) {
+    let read_dir = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) => {
             warn!("Failed to read directory {}: {}", dir.display(), e);
+            if let Ok(utf8) = Utf8PathBuf::try_from(dir.to_path_buf())
+                && let Ok(mut guard) = errors.lock()
+            {
+                // Preserve the first error per unique path.
+                if !guard.iter().any(|(p, _)| p == &utf8) {
+                    guard.push((utf8, e));
+                }
+            }
             return Ok(Vec::new());
         }
     };
 
-    let paths: Vec<Utf8PathBuf> = entries
+    let paths: Vec<Utf8PathBuf> = read_dir
         .flatten()
         .par_bridge()
         .flat_map_iter(|entry| {
+            // Use DirEntry::file_type() — no extra syscall and does NOT follow
+            // symlinks, so a symlink pointing back to a parent cannot cause
+            // infinite recursion.
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(e) => {
+                    warn!("failed to get file type for {:?}: {}", entry.path(), e);
+                    return vec![].into_iter();
+                }
+            };
+
+            // Skip symlinks to prevent cycles.
+            if file_type.is_symlink() {
+                return vec![].into_iter();
+            }
+
             let path = entry.path();
-            if path.is_file() && is_supported_image(&path) {
+
+            if file_type.is_file() && is_supported_image(&path) {
                 match Utf8PathBuf::try_from(path.clone()) {
                     Ok(utf8_path) => vec![utf8_path].into_iter(),
                     Err(_) => {
@@ -83,8 +118,8 @@ fn scan_directory_recursive_parallel(
                         vec![].into_iter()
                     }
                 }
-            } else if path.is_dir() && recursive {
-                match scan_directory_recursive_parallel(&path, recursive, depth + 1) {
+            } else if file_type.is_dir() && recursive {
+                match scan_directory_recursive_parallel(&path, recursive, depth + 1, errors) {
                     Ok(subdir_paths) => subdir_paths.into_iter(),
                     Err(e) => {
                         warn!("failed to scan directory {:?}: {}", path, e);
@@ -102,4 +137,101 @@ fn scan_directory_recursive_parallel(
 
 fn is_supported_image(path: &Path) -> bool {
     image::ImageFormat::from_path(path).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn create_test_image(dir: &Path, name: &str) {
+        // Minimal valid PNG (1x1 white pixel).
+        let path = dir.join(name);
+        let png_bytes: &[u8] = &[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // width=1, height=1
+            0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // bit depth, color type, etc.
+            0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IHDR CRC, IDAT length + type
+            0x54, 0x08, 0xD7, 0x63, 0xF8, 0xFF, 0xFF, 0x3F, // IDAT data
+            0x00, 0x05, 0xFE, 0x02, 0xFE, 0xA1, 0xF4, 0x7D, // IDAT data cont.
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, // IEND
+            0xAE, 0x42, 0x60, 0x82, // IEND CRC
+        ];
+        fs::write(path, png_bytes).unwrap();
+    }
+
+    #[test]
+    fn test_scan_basic() {
+        let dir = tempdir().unwrap();
+        create_test_image(dir.path(), "test.png");
+
+        let utf8_dir = Utf8PathBuf::try_from(dir.path().to_path_buf()).unwrap();
+        let result = scan_image_paths(&[utf8_dir], false);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_scan_empty_dir_returns_no_images_found() {
+        let dir = tempdir().unwrap();
+        let utf8_dir = Utf8PathBuf::try_from(dir.path().to_path_buf()).unwrap();
+        let result = scan_image_paths(&[utf8_dir], false);
+        assert!(matches!(result, Err(SldshowError::NoImagesFound { .. })));
+    }
+
+    /// Symlink pointing back to its parent — scan must not recurse forever and
+    /// must not produce duplicate entries.
+    #[test]
+    fn test_symlink_cycle_does_not_recurse() {
+        let dir = tempdir().unwrap();
+        create_test_image(dir.path(), "img.png");
+
+        let link_path = dir.path().join("self_link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.path(), &link_path).unwrap();
+        #[cfg(windows)]
+        {
+            // Requires Developer Mode or elevation; skip silently if unavailable.
+            if std::os::windows::fs::symlink_dir(dir.path(), &link_path).is_err() {
+                return;
+            }
+        }
+
+        let utf8_dir = Utf8PathBuf::try_from(dir.path().to_path_buf()).unwrap();
+        let result = scan_image_paths(&[utf8_dir], true);
+        assert!(result.is_ok(), "scan should not panic or loop forever");
+        // Symlink is skipped so only the one real image should appear.
+        assert_eq!(
+            result.unwrap().len(),
+            1,
+            "symlink cycle must not produce duplicates"
+        );
+    }
+
+    /// On Unix a directory with mode 0o000 must surface as ScanFailed, not NoImagesFound.
+    #[cfg(unix)]
+    #[test]
+    fn test_permission_denied_surfaces_scan_failed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        create_test_image(&locked, "secret.png");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let utf8_locked = Utf8PathBuf::try_from(locked.clone()).unwrap();
+        let result = scan_image_paths(&[utf8_locked], false);
+
+        // Restore permissions so tempdir cleanup can remove the directory.
+        let _ = fs::set_permissions(&locked, fs::Permissions::from_mode(0o755));
+
+        assert!(
+            matches!(result, Err(SldshowError::ScanFailed { .. })),
+            "permission-denied read_dir should yield ScanFailed, got: {:?}",
+            result
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add `SldshowError::ScanFailed { path, source }` variant to surface fatal `read_dir` I/O errors instead of silently swallowing them as `NoImagesFound`
- Replace `path.is_file()` / `path.is_dir()` (which follow symlinks) with `DirEntry::file_type()` — symlinks are now skipped entirely to prevent cycle recursion
- Add `tempfile` dev-dependency for unit tests

## Test plan

- [ ] `cargo test image_loader::scan` passes (3 tests: basic scan, empty-dir NoImagesFound, symlink-cycle safety)
- [ ] Unix-only `test_permission_denied_surfaces_scan_failed` verifies mode-0o000 dir yields `ScanFailed`
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean

Closes #396
