### PR TITLE
fix: make .sldshow extension check case-insensitive on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,12 @@ fn main() -> Result<()> {
     // viewer.image_paths in the loaded (or default) config.
     let (config_path, cli_image_paths): (Option<Utf8PathBuf>, Vec<Utf8PathBuf>) =
         match args.get(1).map(Utf8PathBuf::from) {
-            Some(p) if p.extension() == Some("sldshow") => (Some(p), vec![]),
+            Some(p)
+                if p.extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("sldshow")) =>
+            {
+                (Some(p), vec![])
+            }
             Some(_) => (None, args[1..].iter().map(Utf8PathBuf::from).collect()),
             None => (None, vec![]),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,12 @@ impl Drop for ScreenSaverGuard {
     fn drop(&mut self) {
         unsafe {
             use windows::Win32::System::Power::{ES_CONTINUOUS, SetThreadExecutionState};
-            SetThreadExecutionState(ES_CONTINUOUS);
+            let prev = SetThreadExecutionState(ES_CONTINUOUS);
+            if prev.0 == 0 {
+                warn!(
+                    "SetThreadExecutionState restore returned 0; system may remain in ES_CONTINUOUS until reboot"
+                );
+            }
         }
     }
 }
@@ -61,7 +66,11 @@ fn main() -> Result<()> {
                 ES_CONTINUOUS, ES_DISPLAY_REQUIRED, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
             };
             // Prevents sleep and screen saver
-            SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            let prev =
+                SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            if prev.0 == 0 {
+                warn!("SetThreadExecutionState failed; screensaver may activate during slideshow");
+            }
         }
         ScreenSaverGuard
     };


### PR DESCRIPTION
## Summary

Replace the case-sensitive extension check `p.extension() == Some("sldshow")` with `p.extension().is_some_and(|e| e.eq_ignore_ascii_case("sldshow"))` so that `.SLDSHOW`, `.Sldshow`, and other mixed-case variants are recognized as config files on Windows.

This PR stacks on / depends on PR #408 (`refactor/issue-404-screensaver-guard-logging`).

Closes #403

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` all 92 tests pass