### PR TITLE
fix: surface error when explicit --config path fails to load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,11 +92,20 @@ fn main() -> Result<()> {
             None => (None, vec![]),
         };
 
-    let mut config = Config::load_default(config_path).unwrap_or_else(|e| {
-        error!("Failed to load config: {}", e);
-        warn!("Using default configuration");
-        Config::default()
-    });
+    let explicit_config = config_path.is_some();
+    let mut config = match Config::load_default(config_path) {
+        Ok(c) => c,
+        Err(e) if explicit_config => {
+            error!("Failed to load config: {}", e);
+            eprintln!("Error: Failed to load config: {e}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            error!("Failed to load config: {}", e);
+            warn!("Using default configuration");
+            Config::default()
+        }
+    };
 
     if !cli_image_paths.is_empty() {
         config.viewer.image_paths = cli_image_paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,12 @@ fn main() -> Result<()> {
     // viewer.image_paths in the loaded (or default) config.
     let (config_path, cli_image_paths): (Option<Utf8PathBuf>, Vec<Utf8PathBuf>) =
         match args.get(1).map(Utf8PathBuf::from) {
-            Some(p) if p.extension() == Some("sldshow") => (Some(p), vec![]),
+            Some(p)
+                if p.extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("sldshow")) =>
+            {
+                (Some(p), vec![])
+            }
             Some(_) => (None, args[1..].iter().map(Utf8PathBuf::from).collect()),
             None => (None, vec![]),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,12 @@ impl Drop for ScreenSaverGuard {
     fn drop(&mut self) {
         unsafe {
             use windows::Win32::System::Power::{ES_CONTINUOUS, SetThreadExecutionState};
-            SetThreadExecutionState(ES_CONTINUOUS);
+            let prev = SetThreadExecutionState(ES_CONTINUOUS);
+            if prev.0 == 0 {
+                warn!(
+                    "SetThreadExecutionState restore returned 0; system may remain in ES_CONTINUOUS until reboot"
+                );
+            }
         }
     }
 }
@@ -61,7 +66,11 @@ fn main() -> Result<()> {
                 ES_CONTINUOUS, ES_DISPLAY_REQUIRED, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
             };
             // Prevents sleep and screen saver
-            SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            let prev =
+                SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+            if prev.0 == 0 {
+                warn!("SetThreadExecutionState failed; screensaver may activate during slideshow");
+            }
         }
         ScreenSaverGuard
     };


### PR DESCRIPTION
## Summary

When the user explicitly passes a `.sldshow` file on the CLI and it fails to parse or validate, the app previously silently fell back to default configuration with only an `error!()` log entry — invisible in release builds that use `windows_subsystem = "windows"`.

This PR splits the error-handling path in `main.rs` to distinguish between:
- **Explicit config** (`config_path.is_some()`): propagate the error, print to stderr via `eprintln!`, and exit with status 1.
- **Auto-discovery** (`~/.sldshow`): retain the existing silent fall-back behaviour — that is intentional.

## Changes

- `src/main.rs`: replace `unwrap_or_else` with a `match` that guards on `explicit_config`, emitting both `error!()` (for log files) and `eprintln!` (for attached consoles) before calling `process::exit(1)`.

## Notes

This PR stacks on PR #414 (which stacks on PR #408). The verify-sprint merge order is: #408 → #414 → this PR.

Closes #401
