### PR TITLE
fix: address Rust 1.94 clippy lints

### DIFF
--- a/examples/generate_test_images.rs
+++ b/examples/generate_test_images.rs
@@ -23,7 +23,7 @@ fn create_checkered_image(width: u32, height: u32, square_size: u32) -> RgbImage
         let square_x = x / square_size;
         let square_y = y / square_size;
 
-        if (square_x + square_y) % 2 == 0 {
+        if (square_x + square_y).is_multiple_of(2) {
             Rgb([255, 255, 255])
         } else {
             Rgb([200, 200, 200])

--- a/src/config.rs
+++ b/src/config.rs
@@ -522,49 +522,41 @@ mod tests {
         assert!(w.decorations);
     }
 
+    fn viewer_with_timer(timer: f32) -> ViewerConfig {
+        ViewerConfig {
+            timer,
+            ..ViewerConfig::default()
+        }
+    }
+
     #[test]
     fn test_timer_validation_zero_is_valid() {
-        let mut config = ViewerConfig::default();
-        config.timer = 0.0;
-        assert!(config.validate().is_ok());
+        assert!(viewer_with_timer(0.0).validate().is_ok());
     }
 
     #[test]
     fn test_timer_validation_above_minimum_is_valid() {
-        let mut config = ViewerConfig::default();
-        config.timer = 0.1;
-        assert!(config.validate().is_ok());
-        config.timer = 5.0;
-        assert!(config.validate().is_ok());
+        assert!(viewer_with_timer(0.1).validate().is_ok());
+        assert!(viewer_with_timer(5.0).validate().is_ok());
     }
 
     #[test]
     fn test_timer_validation_between_zero_and_minimum_is_invalid() {
-        let mut config = ViewerConfig::default();
-        config.timer = 0.05;
-        assert!(config.validate().is_err());
-        config.timer = 0.01;
-        assert!(config.validate().is_err());
-        config.timer = 0.099;
-        assert!(config.validate().is_err());
+        assert!(viewer_with_timer(0.05).validate().is_err());
+        assert!(viewer_with_timer(0.01).validate().is_err());
+        assert!(viewer_with_timer(0.099).validate().is_err());
     }
 
     #[test]
     fn test_timer_validation_negative_is_invalid() {
-        let mut config = ViewerConfig::default();
-        config.timer = -1.0;
-        assert!(config.validate().is_err());
+        assert!(viewer_with_timer(-1.0).validate().is_err());
     }
 
     #[test]
     fn test_timer_validation_non_finite_is_invalid() {
-        let mut config = ViewerConfig::default();
-        config.timer = f32::INFINITY;
-        assert!(config.validate().is_err());
-        config.timer = f32::NEG_INFINITY;
-        assert!(config.validate().is_err());
-        config.timer = f32::NAN;
-        assert!(config.validate().is_err());
+        assert!(viewer_with_timer(f32::INFINITY).validate().is_err());
+        assert!(viewer_with_timer(f32::NEG_INFINITY).validate().is_err());
+        assert!(viewer_with_timer(f32::NAN).validate().is_err());
     }
 
     #[test]

--- a/tests/gpu/helpers.rs
+++ b/tests/gpu/helpers.rs
@@ -290,7 +290,7 @@ pub fn render_transition(
 /// Returns `[r_avg, g_avg, b_avg, a_avg]` as `f32` in `0.0..=255.0`.
 pub fn pixel_avg(pixels: &[u8]) -> [f32; 4] {
     assert!(
-        pixels.len() % 4 == 0,
+        pixels.len().is_multiple_of(4),
         "pixel buffer length not a multiple of 4"
     );
     let count = (pixels.len() / 4) as f32;


### PR DESCRIPTION
## Summary

Rust 1.94 introduced two new clippy lints that flag pre-existing patterns in the codebase. This PR addresses all 5 reported violations so `cargo clippy --all-targets -- -D warnings` is clean again on Rust 1.94+.

## Lints addressed

### `clippy::manual_is_multiple_of`

- `examples/generate_test_images.rs:26` — `(square_x + square_y) % 2 == 0` → `(square_x + square_y).is_multiple_of(2)`
- `tests/gpu/helpers.rs:293` — `pixels.len() % 4 == 0` → `pixels.len().is_multiple_of(4)`

### `clippy::field_reassign_with_default`

In `src/config.rs`, 5 timer-validation tests were using the pattern:

```rust
let mut config = ViewerConfig::default();
config.timer = X;
```

Refactored to use a `viewer_with_timer(t)` helper that builds the config via struct-literal syntax:

```rust
fn viewer_with_timer(timer: f32) -> ViewerConfig {
    ViewerConfig { timer, ..ViewerConfig::default() }
}

#[test]
fn test_timer_validation_zero_is_valid() {
    assert!(viewer_with_timer(0.0).validate().is_ok());
}
```

This also makes the multi-value test cases (`above_minimum_is_valid`, `between_zero_and_minimum_is_invalid`, `non_finite_is_invalid`) shorter and avoids reusing a mutable config across assertions.

## Verification

- `cargo clippy --all-targets -- -D warnings` ✓ clean
- `cargo test` ✓ 105 unit + 21 GPU tests pass
- `cargo fmt --all -- --check` ✓ clean

No behavior change. Detected during `verify-sprint` of the 2026-05-16 robustness expedition (rust-version pinned at 1.92 but local toolchain at 1.94 surfaced these latent lints).
