### PR TITLE
fix: dismiss Settings overlay on outside click

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1507,15 +1507,19 @@ impl ApplicationHandler for ApplicationState {
         }
 
         // imgui WantCaptureMouse pattern: block pointer events from reaching
-        // InputHandler when egui is interested in the pointer.
+        // InputHandler when egui is interested in the pointer, or when a
+        // popup-style overlay is open (so outside clicks dismiss it rather
+        // than passing through to slideshow controls).
         let mut needs_redraw = egui_consumed;
         let egui_wants_pointer = self.egui_overlay.wants_pointer_input();
+        let modal_overlay_open = self.egui_overlay.has_modal_overlay();
         let is_pointer = is_pointer_event(&event);
-        let should_forward = !(egui_consumed || egui_wants_pointer && is_pointer);
+        let should_forward =
+            !(egui_consumed || (egui_wants_pointer || modal_overlay_open) && is_pointer);
 
         // When blocking pointer events, cancel any in-progress drag to
         // prevent stale state from causing unwanted window movement later.
-        if !should_forward && egui_wants_pointer && is_pointer {
+        if !should_forward && (egui_wants_pointer || modal_overlay_open) && is_pointer {
             self.input_handler.cancel_drag();
         }
 

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -313,6 +313,13 @@ impl EguiOverlay {
         self.show_settings || self.show_help_overlay || self.show_gallery || self.osc.visible
     }
 
+    /// Returns `true` when a popup-style overlay is open and should capture
+    /// pointer input even outside its own bounds (so outside clicks dismiss
+    /// it rather than activating slideshow controls underneath).
+    pub fn has_modal_overlay(&self) -> bool {
+        self.show_settings
+    }
+
     fn cleanup_gallery_textures(&mut self, thumbnail_manager: &mut ThumbnailManager) {
         // Remove handles for thumbnails that are no longer in the cache (evicted).
         let cached_indices: std::collections::HashSet<_> =

--- a/src/overlay/settings.rs
+++ b/src/overlay/settings.rs
@@ -12,7 +12,7 @@ pub(super) fn render_settings(
 ) -> Option<OverlayAction> {
     let mut action = None;
 
-    egui::Window::new("Settings")
+    let window_response = egui::Window::new("Settings")
         .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
         .collapsible(false)
         .resizable(true)
@@ -150,6 +150,19 @@ pub(super) fn render_settings(
                 action = Some(OverlayAction::ToggleFullscreen(config.window.fullscreen));
             }
         });
+
+    // Dismiss on primary click outside the window rect (popup-style UX).
+    if let Some(inner) = window_response {
+        let dismiss = ctx.input(|i| {
+            i.pointer.primary_clicked()
+                && i.pointer
+                    .interact_pos()
+                    .is_some_and(|pos| !inner.response.rect.contains(pos))
+        });
+        if dismiss {
+            *show = false;
+        }
+    }
 
     action
 }


### PR DESCRIPTION
## Summary

- Settings overlay now dismisses on primary click outside the window rect (popup-style UX).
- Pointer events are blocked from `InputHandler` while Settings is open, so an outside click no longer also triggers NextImage / drag / etc.
- Existing dismissal paths (X button, Esc, hotkey) are unchanged.

Closes #417

## Implementation

- `src/overlay/settings.rs` — capture `egui::Window::show()` response; if `primary_clicked && !rect.contains(interact_pos)`, set `*show = false`.
- `src/overlay/mod.rs` — new `has_modal_overlay()` accessor (currently `self.show_settings`; ready to extend to other popup-style overlays later).
- `src/app.rs` — extend the "block pointer events from `InputHandler`" gate to also fire when `has_modal_overlay()` is true. The in-progress drag cancellation is widened to the same condition.

## Scope

Settings only. Help has a related but distinct UX (no X button, already documents "Press ? or Escape to close") — left for a separate consideration if desired.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (148 tests pass: 22 + 105 unit, 21 GPU, 0 doc)
- [x] `cargo build --release`
- [ ] Visual:
  - [ ] Open Settings via hotkey, click outside → window dismisses, no NextImage
  - [ ] Open Settings, interact with widgets (slider, checkbox) → window stays open
  - [ ] Open Settings, press Esc → window dismisses (existing path unchanged)
  - [ ] Open Settings, click X → window dismisses (existing path unchanged)
  - [ ] After dismissing, left-click on slideshow area → NextImage works again
