### PR TITLE
docs: establish DESIGN_GUIDELINES.md for overlay theming and contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ issue_*.json
 # Worktrees
 .agent-worktrees/*
 !.agent-worktrees/README.md
+
+# Brainstorming / planning session artifacts
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ For the full Module Map and Architecture details, see **[docs/ARCHITECTURE.md](d
 - **PRs**: Squash merge only. Reference issues with `Closes #N`. No direct push to `main`.
 - **Pre-commit hook**: Runs `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`. Do not skip with `--no-verify`.
 - Always run `cargo fmt --all` before committing.
+- **Overlay UI**: See **[docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md)** for color tokens, contrast rules, and the PR checklist for overlay-touching changes.
 
 ## AI Agent Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ cargo build --release    # Build (use --release for visual testing)
 - **English** for all comments and documentation
 - **Structured logging** via `log` crate (`info!`, `warn!`, `error!`)
 - Avoid global mutable state
+- **Overlay UI styling**: Follow [docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md) — centralized theming via `apply_theme()`, color tokens from Radix Gray Dark, WCAG contrast rules, and PR checklist.
 
 ## Architecture
 For detailed architecture documentation, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -1,0 +1,127 @@
+# sldshow2 Design Guidelines
+
+All overlay visual styling is centralized in `apply_theme(ctx, &config.style)`
+in `src/overlay/mod.rs`. This document defines the rules, tokens, and review
+checklist that govern every overlay UI change.
+
+**Scope:** Settings, Help, Gallery, OSC overlays.  
+**Out of scope:** HUD (filename bar, OSD, info bar) — uses `config.style.text_color` directly.  
+**Light theme:** Not supported. All rules apply to Dark theme only.
+
+## Rules
+
+### Do
+- Use bare `ui.label()`, `ui.heading()`, `ui.button()` in overlay modules and
+  let `apply_theme()` handle all visual properties.
+- Add new styling tokens to `apply_theme()` when a new visual property is needed.
+- Use `RichText::new(...).color(...)` **only** for semantic emphasis:
+
+  | Constant       | Color (approx)                     | Usage                                                          |
+  |----------------|------------------------------------|----------------------------------------------------------------|
+  | `COLOR_ERROR`  | `Color32::from_rgb(220, 80, 80)`   | Error messages                                                 |
+  | `COLOR_WARN`   | `Color32::from_rgb(220, 180, 60)`  | Warnings                                                       |
+  | `COLOR_HINT`   | `Color32::from_rgb(140, 140, 140)` | Dim hints / footers (intentionally low-contrast; decorative secondary text only) |
+
+### Don't
+- Do not call `ui.visuals_mut()`, `ui.style_mut()`, or `ctx.set_style()` inside
+  overlay modules — those belong exclusively in `apply_theme()`.
+- Do not use `Color32::GRAY`, `Color32::WHITE`, or any ad-hoc literal color
+  outside of `apply_theme()` and the semantic constants above.
+- Do not use `set_global_style()` — it writes only the current theme slot.
+  Use `ctx.style_mut()` scoped to Dark inside `apply_theme()` instead.
+
+## Color Tokens
+
+All tokens are fixed constants defined in `apply_theme()`. Values follow the
+**Radix UI Gray Dark** scale (<https://www.radix-ui.com/colors>).
+
+| Constant                | Radix Step    | Hex         | Usage                              |
+|-------------------------|---------------|-------------|------------------------------------|
+| `PANEL_FILL`            | Gray Dark 2   | `#191919`   | Window / panel background          |
+| `WIDGET_BG`             | Gray Dark 4   | `#2a2a2a`   | Button / input background          |
+| `WIDGET_BG_HOVERED`     | Gray Dark 5   | `#313131`   | Hover state                        |
+| `WIDGET_BG_ACTIVE`      | Gray Dark 6   | `#3a3a3a`   | Pressed / active state             |
+| `SEPARATOR`             | Gray Dark 6   | `#3a3a3a`   | `ui.separator()` stroke            |
+| `TEXT_PRIMARY`          | Gray Dark 12  | `#eeeeee`   | Body text, labels                  |
+| `TEXT_HEADING`          | Gray Dark 12  | `#eeeeee`   | Headings                           |
+| `STROKE_NONINTERACTIVE` | Gray Dark 12  | `#eeeeee`   | Non-interactive widget text        |
+
+**Contrast requirements (measured against `PANEL_FILL`):**
+- Body text / labels: **≥ 7:1**
+- Headings: **≥ 4.5:1**
+- Non-text UI elements (separators, widget borders): no minimum.
+
+**Contrast formula:**
+
+```
+ratio = (L_lighter + 0.05) / (L_darker + 0.05)
+L = 0.2126·R + 0.7152·G + 0.0722·B
+```
+
+where R, G, B are linearized from sRGB:
+`c_lin = (c/255 / 12.92)` if `c/255 ≤ 0.04045`, else `((c/255 + 0.055) / 1.055)^2.4`
+
+## Spacing Tokens
+
+Set once in `apply_theme()` via `style.spacing.*`. Overlay modules must not
+override these locally.
+
+| Field                   | Value            | Usage                                       |
+|-------------------------|------------------|---------------------------------------------|
+| `spacing.item_spacing`  | `(8.0, 8.0)`     | Vertical / horizontal gap between widgets   |
+| `spacing.window_margin` | `12` (all sides) | Window inner padding                        |
+| `spacing.button_padding`| egui default     | Do not override                             |
+| `spacing.indent`        | egui default     | Do not override                             |
+
+> **Exception:** `gallery.rs` adjusts `item_spacing` locally for the thumbnail
+> grid cell layout. This is permitted because it is a layout-level override
+> scoped to the scroll area, not a color or text style override.
+
+## PR Review Checklist
+
+Apply to every PR that touches `src/overlay/` or `src/osc.rs`.
+
+### Required checks
+
+- [ ] No new `.color(...)` calls outside `apply_theme()` and the three semantic
+      constants (`COLOR_ERROR`, `COLOR_WARN`, `COLOR_HINT`).
+- [ ] New overlays use bare `ui.label()` / `ui.heading()` — no local
+      `visuals_mut()` / `style_mut()` calls.
+- [ ] If `apply_theme()` was modified: manually verify Settings, Help, Gallery,
+      and OSC all render correctly.
+
+### Contrast check (required when adding or changing text)
+
+Compute contrast ratio against `PANEL_FILL` using the formula in the Color
+Tokens section. Confirm:
+- Body text: ≥ 7:1
+- Headings: ≥ 4.5:1
+
+### Screenshot (required when adding or changing an overlay)
+
+Capture the affected overlay with `--auto-screenshot` and attach the PNG to
+the PR description.
+
+> **NOTE:** `--auto-screenshot` is not yet available (tracked in #421).
+> Until #421 lands, take a manual screenshot with the `S` key and attach it.
+
+### Not required
+
+- Light theme testing — Light is not supported (see Scope).
+
+## Notes
+
+### HUD colors (`config.style.text_color`)
+
+The filename bar, OSD, and info bar use `config.style.text_color` via `RichText`
+and are intentionally excluded from `apply_theme()`. Users may set this color in
+their TOML config. `config.style.bg_color` is similarly user-configurable.
+
+These fields are candidates for future cleanup once a more complete theming
+system is designed, but removal is out of scope for this initiative.
+
+### Light theme
+
+Light theme is not supported. `apply_theme()` writes only the Dark style slot.
+If Light theme support is added in the future, a separate pass updating this
+document and `apply_theme()` will be required.

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -4,6 +4,12 @@ All overlay visual styling is centralized in `apply_theme(ctx, &config.style)`
 in `src/overlay/mod.rs`. This document defines the rules, tokens, and review
 checklist that govern every overlay UI change.
 
+> **Note:** `apply_theme()` is not yet implemented. It is the target state
+> described by this document and will be introduced in [#420]. Until #420 lands,
+> styling is applied in `EguiOverlay::new()` via `context.set_global_style()`.
+> The rules in this document are aspirational — follow them in new code and
+> apply them when modifying existing overlays.
+
 **Scope:** Settings, Help, Gallery, OSC overlays.  
 **Out of scope:** HUD (filename bar, OSD, info bar) — uses `config.style.text_color` directly.  
 **Light theme:** Not supported. All rules apply to Dark theme only.
@@ -46,9 +52,14 @@ All tokens are fixed constants defined in `apply_theme()`. Values follow the
 | `TEXT_HEADING`          | Gray Dark 12  | `#eeeeee`   | Headings                           |
 | `STROKE_NONINTERACTIVE` | Gray Dark 12  | `#eeeeee`   | Non-interactive widget text        |
 
+> **Source:** Hex values are from `@radix-ui/colors@3.0.0` (fetched 2026-05-17).
+> If updating, copy values directly from <https://www.radix-ui.com/colors> (Gray Dark scale).
+
 **Contrast requirements (measured against `PANEL_FILL`):**
 - Body text / labels: **≥ 7:1**
 - Headings: **≥ 4.5:1**
+  (WCAG AA body-text standard applied to headings for consistency; WCAG permits ≥ 3:1
+  for large text but we use the stricter threshold throughout.)
 - Non-text UI elements (separators, widget borders): no minimum.
 
 **Contrast formula:**
@@ -59,7 +70,7 @@ L = 0.2126·R + 0.7152·G + 0.0722·B
 ```
 
 where R, G, B are linearized from sRGB:
-`c_lin = (c/255 / 12.92)` if `c/255 ≤ 0.04045`, else `((c/255 + 0.055) / 1.055)^2.4`
+`c_lin = (c/255) / 12.92` if `c/255 ≤ 0.04045`, else `((c/255 + 0.055) / 1.055)^2.4`
 
 ## Spacing Tokens
 
@@ -79,7 +90,7 @@ override these locally.
 
 ## PR Review Checklist
 
-Apply to every PR that touches `src/overlay/` or `src/osc.rs`.
+Apply to every PR that touches `src/overlay/` or `src/osc.rs` (OSC renders egui widgets directly and is subject to the same theming rules as the overlay modules).
 
 ### Required checks
 
@@ -96,6 +107,10 @@ Compute contrast ratio against `PANEL_FILL` using the formula in the Color
 Tokens section. Confirm:
 - Body text: ≥ 7:1
 - Headings: ≥ 4.5:1
+
+> **Semantic constants exempt:** `COLOR_ERROR`, `COLOR_WARN`, and `COLOR_HINT` are
+> pre-approved and do not require per-PR contrast computation. Their values are
+> intentionally chosen for semantic clarity, not strict WCAG compliance.
 
 ### Screenshot (required when adding or changing an overlay)
 

--- a/docs/superpowers/plans/2026-05-17-design-guidelines.md
+++ b/docs/superpowers/plans/2026-05-17-design-guidelines.md
@@ -1,0 +1,345 @@
+# Design Guidelines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `docs/DESIGN_GUIDELINES.md` as the single source of truth for overlay visual conventions and link it from `CLAUDE.md` and `CONTRIBUTING.md`.
+
+**Architecture:** Documentation-only change. No Rust code is modified. The guideline document uses Rule-first structure: Rules → Color Tokens (Radix Gray Dark scale) → Spacing Tokens → PR Checklist. Color token values follow the Radix UI Gray Dark scale; exact hex must be copied from https://www.radix-ui.com/colors at write time.
+
+**Tech Stack:** Markdown, Radix UI Gray Dark color scale reference.
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Create | `docs/DESIGN_GUIDELINES.md` | The guideline document (deliverable) |
+| Modify | `CLAUDE.md` | Add reference link under Conventions section |
+| Modify | `CONTRIBUTING.md` | Add reference link under Code Style section |
+| Modify | `.gitignore` | Add `.superpowers/` entry |
+
+---
+
+### Task 1: Add `.superpowers/` to `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Append the entry**
+
+Open `.gitignore` and add at the end:
+
+```
+# Brainstorming / planning session artifacts
+.superpowers/
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "superpowers" .gitignore
+```
+
+Expected output:
+```
+.superpowers/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: ignore .superpowers/ brainstorm artifacts"
+```
+
+---
+
+### Task 2: Create `docs/DESIGN_GUIDELINES.md`
+
+**Files:**
+- Create: `docs/DESIGN_GUIDELINES.md`
+
+Before writing, fetch the exact Radix UI Gray Dark hex values from
+https://www.radix-ui.com/colors (Gray → Dark tab). You need steps 2, 4, 5, 6, 12.
+
+- [ ] **Step 1: Verify Radix Gray Dark values**
+
+Open https://www.radix-ui.com/colors in a browser, select **Gray** → **Dark**.
+Record the exact hex for:
+- Step 2 → `PANEL_FILL`
+- Step 4 → `WIDGET_BG`
+- Step 5 → `WIDGET_BG_HOVERED`
+- Step 6 → `WIDGET_BG_ACTIVE` and `SEPARATOR`
+- Step 12 → `TEXT_PRIMARY`, `TEXT_HEADING`, `STROKE_NONINTERACTIVE`
+
+- [ ] **Step 2: Verify contrast ratios**
+
+For each text token, compute the contrast ratio against `PANEL_FILL` using:
+
+```
+L(hex) = 0.2126·R_lin + 0.7152·G_lin + 0.0722·B_lin
+R_lin = (R/255)^2.2  (simplified sRGB linearization)
+ratio = (L_lighter + 0.05) / (L_darker + 0.05)
+```
+
+Confirm:
+- `TEXT_PRIMARY` (Gray Dark 12) vs `PANEL_FILL` (Gray Dark 2) ≥ 7:1  ✓ (expect ~12–14:1)
+- `TEXT_HEADING` same token, same check ✓
+
+- [ ] **Step 3: Write the file**
+
+Create `docs/DESIGN_GUIDELINES.md` with the following content, substituting
+`<STEP_N_HEX>` with the actual values from Step 1:
+
+```markdown
+# sldshow2 Design Guidelines
+
+All overlay visual styling is centralized in `apply_theme(ctx, &config.style)`
+in `src/overlay/mod.rs`. This document defines the rules, tokens, and review
+checklist that govern every overlay UI change.
+
+**Scope:** Settings, Help, Gallery, OSC overlays.  
+**Out of scope:** HUD (filename bar, OSD, info bar) — uses `config.style.text_color` directly.  
+**Light theme:** Not supported. All rules apply to Dark theme only.
+
+## Rules
+
+### Do
+- Use bare `ui.label()`, `ui.heading()`, `ui.button()` in overlay modules and
+  let `apply_theme()` handle all visual properties.
+- Add new styling tokens to `apply_theme()` when a new visual property is needed.
+- Use `RichText::new(...).color(...)` **only** for semantic emphasis:
+
+  | Constant       | Color (approx)                     | Usage                                                          |
+  |----------------|------------------------------------|----------------------------------------------------------------|
+  | `COLOR_ERROR`  | `Color32::from_rgb(220, 80, 80)`   | Error messages                                                 |
+  | `COLOR_WARN`   | `Color32::from_rgb(220, 180, 60)`  | Warnings                                                       |
+  | `COLOR_HINT`   | `Color32::from_rgb(140, 140, 140)` | Dim hints / footers (intentionally low-contrast; decorative secondary text only) |
+
+### Don't
+- Do not call `ui.visuals_mut()`, `ui.style_mut()`, or `ctx.set_style()` inside
+  overlay modules — those belong exclusively in `apply_theme()`.
+- Do not use `Color32::GRAY`, `Color32::WHITE`, or any ad-hoc literal color
+  outside of `apply_theme()` and the semantic constants above.
+- Do not use `set_global_style()` — it writes only the current theme slot.
+  Use `ctx.style_mut()` scoped to Dark inside `apply_theme()` instead.
+
+## Color Tokens
+
+All tokens are fixed constants defined in `apply_theme()`. Values follow the
+**Radix UI Gray Dark** scale (<https://www.radix-ui.com/colors>).
+
+| Constant                | Radix Step    | Hex         | Usage                              |
+|-------------------------|---------------|-------------|------------------------------------|
+| `PANEL_FILL`            | Gray Dark 2   | `<STEP_2_HEX>`  | Window / panel background      |
+| `WIDGET_BG`             | Gray Dark 4   | `<STEP_4_HEX>`  | Button / input background      |
+| `WIDGET_BG_HOVERED`     | Gray Dark 5   | `<STEP_5_HEX>`  | Hover state                    |
+| `WIDGET_BG_ACTIVE`      | Gray Dark 6   | `<STEP_6_HEX>`  | Pressed / active state         |
+| `SEPARATOR`             | Gray Dark 6   | `<STEP_6_HEX>`  | `ui.separator()` stroke        |
+| `TEXT_PRIMARY`          | Gray Dark 12  | `<STEP_12_HEX>` | Body text, labels              |
+| `TEXT_HEADING`          | Gray Dark 12  | `<STEP_12_HEX>` | Headings                       |
+| `STROKE_NONINTERACTIVE` | Gray Dark 12  | `<STEP_12_HEX>` | Non-interactive widget text    |
+
+**Contrast requirements (measured against `PANEL_FILL`):**
+- Body text / labels: **≥ 7:1**
+- Headings: **≥ 4.5:1**
+- Non-text UI elements (separators, widget borders): no minimum.
+
+**Contrast formula:**
+
+```
+ratio = (L_lighter + 0.05) / (L_darker + 0.05)
+L = 0.2126·R + 0.7152·G + 0.0722·B
+```
+
+where R, G, B are linearized from sRGB:
+`c_lin = (c/255 / 12.92)` if `c/255 ≤ 0.04045`, else `((c/255 + 0.055) / 1.055)^2.4`
+
+## Spacing Tokens
+
+Set once in `apply_theme()` via `style.spacing.*`. Overlay modules must not
+override these locally.
+
+| Field                   | Value            | Usage                                       |
+|-------------------------|------------------|---------------------------------------------|
+| `spacing.item_spacing`  | `(8.0, 8.0)`     | Vertical / horizontal gap between widgets   |
+| `spacing.window_margin` | `12` (all sides) | Window inner padding                        |
+| `spacing.button_padding`| egui default     | Do not override                             |
+| `spacing.indent`        | egui default     | Do not override                             |
+
+> **Exception:** `gallery.rs` adjusts `item_spacing` locally for the thumbnail
+> grid cell layout. This is permitted because it is a layout-level override
+> scoped to the scroll area, not a color or text style override.
+
+## PR Review Checklist
+
+Apply to every PR that touches `src/overlay/` or `src/osc.rs`.
+
+### Required checks
+
+- [ ] No new `.color(...)` calls outside `apply_theme()` and the three semantic
+      constants (`COLOR_ERROR`, `COLOR_WARN`, `COLOR_HINT`).
+- [ ] New overlays use bare `ui.label()` / `ui.heading()` — no local
+      `visuals_mut()` / `style_mut()` calls.
+- [ ] If `apply_theme()` was modified: manually verify Settings, Help, Gallery,
+      and OSC all render correctly.
+
+### Contrast check (required when adding or changing text)
+
+Compute contrast ratio against `PANEL_FILL` using the formula in the Color
+Tokens section. Confirm:
+- Body text: ≥ 7:1
+- Headings: ≥ 4.5:1
+
+### Screenshot (required when adding or changing an overlay)
+
+Capture the affected overlay with `--auto-screenshot` and attach the PNG to
+the PR description.
+
+> **NOTE:** `--auto-screenshot` is not yet available (tracked in #421).
+> Until #421 lands, take a manual screenshot with the `S` key and attach it.
+
+### Not required
+
+- Light theme testing — Light is not supported (see Scope).
+
+## Notes
+
+### HUD colors (`config.style.text_color`)
+
+The filename bar, OSD, and info bar use `config.style.text_color` via `RichText`
+and are intentionally excluded from `apply_theme()`. Users may set this color in
+their TOML config. `config.style.bg_color` is similarly user-configurable.
+
+These fields are candidates for future cleanup once a more complete theming
+system is designed, but removal is out of scope for this initiative.
+
+### Light theme
+
+Light theme is not supported. `apply_theme()` writes only the Dark style slot.
+If Light theme support is added in the future, a separate pass updating this
+document and `apply_theme()` will be required.
+```
+
+- [ ] **Step 4: Verify required sections exist**
+
+```bash
+grep -c "^## " docs/DESIGN_GUIDELINES.md
+```
+
+Expected: `4` (Rules, Color Tokens, Spacing Tokens, PR Review Checklist)
+
+```bash
+grep "PANEL_FILL\|TEXT_PRIMARY\|WIDGET_BG\|SEPARATOR\|STROKE_NONINTERACTIVE" docs/DESIGN_GUIDELINES.md | wc -l
+```
+
+Expected: at least `8` lines (one per token).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/DESIGN_GUIDELINES.md
+git commit -m "docs: add DESIGN_GUIDELINES.md for overlay theming and contrast (#419)"
+```
+
+---
+
+### Task 3: Link from `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add reference under Conventions**
+
+In `CLAUDE.md`, find the `## Conventions` section. Add a line at the end of
+the bullet list:
+
+```markdown
+- **Overlay UI**: See **[docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md)** for color tokens, contrast rules, and the PR checklist for overlay-touching changes.
+```
+
+The section should look like:
+
+```markdown
+## Conventions
+
+- **Commit/PR/issue/branch titles**: [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `refactor:`, etc.
+- **Branch names**: `feat/kebab-description`, `fix/kebab-description`
+- **PRs**: Squash merge only. Reference issues with `Closes #N`. No direct push to `main`.
+- **Pre-commit hook**: Runs `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`. Do not skip with `--no-verify`.
+- Always run `cargo fmt --all` before committing.
+- **Overlay UI**: See **[docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md)** for color tokens, contrast rules, and the PR checklist for overlay-touching changes.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "DESIGN_GUIDELINES" CLAUDE.md
+```
+
+Expected:
+```
+- **Overlay UI**: See **[docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md)** for color tokens...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: link DESIGN_GUIDELINES.md from CLAUDE.md"
+```
+
+---
+
+### Task 4: Link from `CONTRIBUTING.md`
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Add reference under Code Style**
+
+In `CONTRIBUTING.md`, find the `## Code Style` section. Add at the end of
+that section (before `## Architecture`):
+
+```markdown
+- **Overlay UI styling**: Follow [docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md) — centralized theming via `apply_theme()`, color tokens from Radix Gray Dark, WCAG contrast rules, and PR checklist.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "DESIGN_GUIDELINES" CONTRIBUTING.md
+```
+
+Expected:
+```
+- **Overlay UI styling**: Follow [docs/DESIGN_GUIDELINES.md](docs/DESIGN_GUIDELINES.md)...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: link DESIGN_GUIDELINES.md from CONTRIBUTING.md"
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+After all tasks are complete, verify the three acceptance criteria from issue #419:
+
+```bash
+# 1. File exists and is linked
+ls docs/DESIGN_GUIDELINES.md
+grep "DESIGN_GUIDELINES" CLAUDE.md CONTRIBUTING.md
+
+# 2. Contrast rule is concrete (contains formula and numeric thresholds)
+grep "7:1\|4.5:1\|0.2126" docs/DESIGN_GUIDELINES.md
+
+# 3. Token table exists (tokens will map 1:1 to apply_theme() fields in #420)
+grep "PANEL_FILL\|TEXT_PRIMARY\|WIDGET_BG" docs/DESIGN_GUIDELINES.md
+```
+
+All three commands must produce non-empty output.

--- a/docs/superpowers/specs/2026-05-17-overlay-design-guidelines-design.md
+++ b/docs/superpowers/specs/2026-05-17-overlay-design-guidelines-design.md
@@ -1,0 +1,175 @@
+# Design Spec: DESIGN_GUIDELINES.md for Overlay Theming
+
+**Issue:** #419  
+**Date:** 2026-05-17  
+**Status:** Approved
+
+## Context
+
+Overlay UI styling is fragmented across three implicit conventions in sldshow2:
+1. Bare egui defaults — `settings.rs`, `help.rs` (root cause of visibility complaint)
+2. `config.style.text_color` via RichText — filename / OSD / info bar in `mod.rs`
+3. Ad-hoc per-widget tweaks — gallery spacing, OSC hand-drawn background, `Color32::GRAY` in `help.rs`
+
+This spec defines what `docs/DESIGN_GUIDELINES.md` must contain and the design decisions agreed upon.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Contrast standard | Body ≥ 7:1, headings ≥ 4.5:1 (fixed values) | Visible improvement over egui default ~4.5:1; numeric enough for agent checks |
+| Theme scope | Dark only; Light unsupported | sldshow2 is a dark-first image viewer |
+| Color tokens | Fixed constants; not user-configurable | Simplicity; avoids user breaking contrast |
+| HUD colors | Excluded from apply_theme(); stays on `config.style.text_color` | HUD is user-configurable by design |
+| Color reference | Radix UI Gray Dark scale | Principled, well-documented, semantic step names |
+| apply_theme() scope | Settings, Help, Gallery, OSC | HUD excluded |
+| PR checklist | Medium (6 items); --auto-screenshot step gated on #421 | Balances rigor with tooling availability |
+| Document structure | Rule-first | Rules before tokens; most important info first |
+
+## Deliverable
+
+The agent implementing #419 must create `docs/DESIGN_GUIDELINES.md` with the
+exact structure and content defined below.
+
+---
+
+## Draft: docs/DESIGN_GUIDELINES.md
+
+```markdown
+# sldshow2 Design Guidelines
+
+All overlay visual styling is centralized in `apply_theme(ctx, &config.style)`
+in `src/overlay/mod.rs`. This document defines the rules, tokens, and review
+checklist that govern every overlay UI change.
+
+**Scope:** Settings, Help, Gallery, OSC overlays.  
+**Out of scope:** HUD (filename bar, OSD, info bar) — uses `config.style.text_color` directly.  
+**Light theme:** Not supported. All rules apply to Dark theme only.
+
+## Rules
+
+### Do
+- Use bare `ui.label()`, `ui.heading()`, `ui.button()` in overlay modules and
+  let `apply_theme()` handle all visual properties.
+- Add new styling tokens to `apply_theme()` when a new visual property is needed.
+- Use `RichText::new(...).color(...)` **only** for semantic emphasis:
+
+  | Constant       | Color (approx)             | Usage               |
+  |----------------|----------------------------|---------------------|
+  | `COLOR_ERROR`  | `Color32::from_rgb(220, 80, 80)`  | Error messages |
+  | `COLOR_WARN`   | `Color32::from_rgb(220, 180, 60)` | Warnings       |
+  | `COLOR_HINT`   | `Color32::from_rgb(140, 140, 140)`| Dim hints / footers (intentionally low-contrast; for decorative secondary text only) |
+
+### Don't
+- Do not call `ui.visuals_mut()`, `ui.style_mut()`, or `ctx.set_style()` inside
+  overlay modules — those belong exclusively in `apply_theme()`.
+- Do not use `Color32::GRAY`, `Color32::WHITE`, or any ad-hoc literal color
+  outside of `apply_theme()` and the semantic constants above.
+- Do not use `set_global_style()` — it writes only the current theme slot.
+  Use `ctx.style_mut()` scoped to Dark inside `apply_theme()` instead.
+
+## Color Tokens
+
+All tokens are fixed constants defined in `apply_theme()`. Values follow the
+**Radix UI Gray Dark** scale (<https://www.radix-ui.com/colors>).
+
+| Constant                | Radix Step    | Approx hex  | Usage                              |
+|-------------------------|---------------|-------------|------------------------------------|
+| `PANEL_FILL`            | Gray Dark 2   | `#191919`   | Window / panel background          |
+| `WIDGET_BG`             | Gray Dark 4   | `#2b2b2b`   | Button / input background          |
+| `WIDGET_BG_HOVERED`     | Gray Dark 5   | `#333333`   | Hover state                        |
+| `WIDGET_BG_ACTIVE`      | Gray Dark 6   | `#3c3c3c`   | Pressed / active state             |
+| `SEPARATOR`             | Gray Dark 6   | `#3c3c3c`   | `ui.separator()` stroke            |
+| `TEXT_PRIMARY`          | Gray Dark 12  | `#eeeeee`   | Body text, labels  (≈ 14:1 ✓)     |
+| `TEXT_HEADING`          | Gray Dark 12  | `#eeeeee`   | Headings                           |
+| `STROKE_NONINTERACTIVE` | Gray Dark 12  | `#eeeeee`   | Non-interactive widget text        |
+
+> **Implementation note:** Confirm exact hex values from <https://www.radix-ui.com/colors>
+> at implementation time. Copy values directly from the Radix source; do not approximate.
+
+**Contrast requirements (measured against `PANEL_FILL`):**
+- Body text / labels: **≥ 7:1**
+- Headings: **≥ 4.5:1**
+- Non-text UI elements (separators, widget borders): no minimum.
+
+**Contrast formula:**
+
+```
+ratio = (L_lighter + 0.05) / (L_darker + 0.05)
+L = 0.2126·R + 0.7152·G + 0.0722·B   (R, G, B linearized from sRGB: x/255 if ≤ 0.04045, else ((x/255 + 0.055)/1.055)^2.4)
+```
+
+## Spacing Tokens
+
+Set once in `apply_theme()` via `style.spacing.*`. Overlay modules must not
+override these locally.
+
+| Field                   | Value            | Usage                                   |
+|-------------------------|------------------|-----------------------------------------|
+| `spacing.item_spacing`  | `(8.0, 8.0)`     | Vertical / horizontal gap between widgets |
+| `spacing.window_margin` | `12` (all sides) | Window inner padding                    |
+| `spacing.button_padding`| egui default     | Do not override                         |
+| `spacing.indent`        | egui default     | Do not override                         |
+
+> **Exception:** `gallery.rs` adjusts `item_spacing` locally for the thumbnail
+> grid cell layout. This is permitted because it is a layout-level override
+> scoped to the scroll area, not a color or text style override.
+
+## PR Review Checklist
+
+Apply to every PR that touches `src/overlay/` or `src/osc.rs`.
+
+### Required checks
+
+- [ ] No new `.color(...)` calls outside `apply_theme()` and the three semantic
+      constants (`COLOR_ERROR`, `COLOR_WARN`, `COLOR_HINT`).
+- [ ] New overlays use bare `ui.label()` / `ui.heading()` — no local
+      `visuals_mut()` / `style_mut()` calls.
+- [ ] If `apply_theme()` was modified: manually verify Settings, Help, Gallery,
+      and OSC all render correctly.
+
+### Contrast check (required when adding or changing text)
+
+Compute contrast ratio against `PANEL_FILL` using the formula in the Color
+Tokens section. Confirm:
+- Body text: ≥ 7:1
+- Headings: ≥ 4.5:1
+
+### Screenshot (required when adding or changing an overlay)
+
+Capture the affected overlay with `--auto-screenshot` and attach the PNG to
+the PR description.
+
+> **NOTE:** `--auto-screenshot` is not yet available (tracked in #421).
+> Until #421 lands, take a manual screenshot with the `S` key and attach it.
+
+### Not required
+
+- Light theme testing — Light is not supported (see Scope).
+
+## Notes
+
+### HUD colors (config.style.text_color)
+
+The filename bar, OSD, and info bar use `config.style.text_color` via `RichText`
+and are intentionally excluded from `apply_theme()`. Users may set this color in
+their TOML config. `config.style.bg_color` is similarly user-configurable and
+excluded from centralized theming.
+
+These fields are candidates for future cleanup once a more complete theming
+system is designed, but removal is out of scope for this initiative.
+
+### Light theme
+
+Light theme is not supported. `apply_theme()` writes only the Dark style slot.
+If Light theme support is added in the future, a separate pass updating this
+document and `apply_theme()` will be required.
+```
+
+## References
+
+- Issue #420: implement `apply_theme()` (depends on this spec)
+- Issue #421: `--auto-screenshot` CLI flag (enables checklist screenshot step)
+- Issue #422: vision-model reviewer agent (depends on #419 + #421)
+- Issue #423: parent epic
+- Radix UI Colors: https://www.radix-ui.com/colors


### PR DESCRIPTION
## Summary

- Add `docs/DESIGN_GUIDELINES.md` as the single source of truth for overlay visual conventions: Rule-first structure covering color tokens (Radix UI Gray Dark scale), contrast requirements (body ≥ 7:1, headings ≥ 4.5:1), spacing tokens, and a PR review checklist.
- Link the guidelines from `CLAUDE.md` (Conventions section) and `CONTRIBUTING.md` (Code Style section) so they are discoverable by both humans and agents.
- Add `.superpowers/` to `.gitignore` (brainstorm session artifacts).

## Design decisions (from brainstorm session)

- **Color tokens**: fixed constants based on Radix UI Gray Dark scale (`@radix-ui/colors@3.0.0`); not user-configurable.
- **Scope**: Settings, Help, Gallery, OSC overlays. HUD (filename/OSD/info bar) intentionally excluded — stays on `config.style.text_color`.
- **Dark only**: Light theme is unsupported and documented as such.
- **`apply_theme()` is aspirational**: the function does not yet exist; it is the target of #420. Document includes a prominent note to that effect.

## Test Plan

- [x] `cargo test` passes (21/21)
- [x] `docs/DESIGN_GUIDELINES.md` contains all 8 color tokens, contrast formula, spacing tokens, and PR checklist
- [x] Both `CLAUDE.md` and `CONTRIBUTING.md` link to the guidelines
- [x] No placeholder text (`STEP_N_HEX`) remains in the document

Closes #419
