### PR TITLE
fix: add explicit f32 suffix to float literal in osc.rs

### DIFF
--- a/src/osc.rs
+++ b/src/osc.rs
@@ -87,7 +87,7 @@ impl Osc {
                         bottom: 12,
                     })
                     .corner_radius(12.0)
-                    .stroke(Stroke::new(1.0, Color32::from_white_alpha(30)));
+                    .stroke(Stroke::new(1.0_f32, Color32::from_white_alpha(30)));
 
                 frame.show(ui, |ui| {
                     ui.vertical(|ui| {


### PR DESCRIPTION
Add `_f32` suffix to a float literal in `src/osc.rs` that was triggering the `float_literal_f32_fallback` Clippy lint under `-D warnings` with newer Rust toolchains.

The literal `1.0` passed to `Stroke::new(...)` now reads `1.0_f32`, satisfying the lint without changing any behavior.

This unblocks Dependabot PR #441 (exr 1.74.0 → 1.74.2), which was failing CI solely due to this pre-existing lint error.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ePnzxVv3f1jKB9nGpusGe)_